### PR TITLE
⚡ Bolt: Optimize LibraryGrid rendering performance

### DIFF
--- a/renderer/src/components/LibraryGrid.tsx
+++ b/renderer/src/components/LibraryGrid.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import {
   DndContext,
   closestCenter,
@@ -157,6 +157,12 @@ export const LibraryGrid: React.FC<LibraryGridProps> = ({
     }
   };
 
+  const handleFocusItem = useCallback((index: number) => {
+    setFocusedIndex(index);
+  }, []);
+
+  const itemIds = useMemo(() => items.map((g) => g.id), [items]);
+
   return (
     <div className="w-full h-full flex flex-col">
       {/* Grid Container */}
@@ -178,7 +184,7 @@ export const LibraryGrid: React.FC<LibraryGridProps> = ({
           collisionDetection={closestCenter}
           onDragEnd={handleDragEnd}
         >
-          <SortableContext items={items.map((g) => g.id)} strategy={rectSortingStrategy}>
+          <SortableContext items={itemIds} strategy={rectSortingStrategy}>
             <div
               className="grid"
               style={{
@@ -216,7 +222,8 @@ export const LibraryGrid: React.FC<LibraryGridProps> = ({
                   logoBackgroundOpacity={logoBackgroundOpacity}
                   tabIndex={0}
                   isFocused={index === focusedIndex}
-                  onFocus={() => setFocusedIndex(index)}
+                  onFocusItem={handleFocusItem}
+                  index={index}
                 />
               ))}
             </div>

--- a/renderer/src/components/SortableGameCard.tsx
+++ b/renderer/src/components/SortableGameCard.tsx
@@ -21,9 +21,11 @@ interface SortableGameCardProps {
   tabIndex?: number;
   isFocused?: boolean;
   onFocus?: () => void;
+  onFocusItem?: (index: number) => void;
+  index?: number;
 }
 
-export const SortableGameCard: React.FC<SortableGameCardProps> = ({ game, onPlay, onClick, onEdit, hideTitle = false, showLogoOverBoxart = true, logoPosition = 'middle', useLogoInsteadOfBoxart = false, descriptionSize = 14, onContextMenu, viewMode, logoBackgroundColor, logoBackgroundOpacity, tabIndex, isFocused, onFocus }) => {
+const SortableGameCardComponent: React.FC<SortableGameCardProps> = ({ game, onPlay, onClick, onEdit, hideTitle = false, showLogoOverBoxart = true, logoPosition = 'middle', useLogoInsteadOfBoxart = false, descriptionSize = 14, onContextMenu, viewMode, logoBackgroundColor, logoBackgroundOpacity, tabIndex, isFocused, onFocus, onFocusItem, index }) => {
   const {
     attributes,
     listeners,
@@ -70,6 +72,18 @@ export const SortableGameCard: React.FC<SortableGameCardProps> = ({ game, onPlay
     onContextMenu: handleContextMenu,
   };
 
+  const handleFocus = React.useCallback(
+    (_: React.FocusEvent<HTMLDivElement>) => {
+      // We don't need to prevent default or stop propagation here
+      // just notify the parent about focus
+      if (onFocus) onFocus();
+      if (index !== undefined && onFocusItem) {
+        onFocusItem(index);
+      }
+    },
+    [onFocus, onFocusItem, index]
+  );
+
   return (
     <div
       ref={setNodeRef}
@@ -78,7 +92,7 @@ export const SortableGameCard: React.FC<SortableGameCardProps> = ({ game, onPlay
       {...mergedListeners}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
-      onFocus={onFocus}
+      onFocus={handleFocus}
       tabIndex={tabIndex}
       className={`cursor-pointer outline-none transition-all duration-200 ${isFocused ? 'rounded-xl animate-breathing-scale z-10' : ''}`}
       data-game-card
@@ -87,3 +101,5 @@ export const SortableGameCard: React.FC<SortableGameCardProps> = ({ game, onPlay
     </div>
   );
 };
+
+export const SortableGameCard = React.memo(SortableGameCardComponent);


### PR DESCRIPTION
💡 What: Optimized `LibraryGrid` and `SortableGameCard` to prevent unnecessary re-renders during keyboard navigation and other state updates.

🎯 Why: Previously, updating the `focusedIndex` (e.g., via arrow keys) caused the entire `LibraryGrid` to re-render, creating a new inline `onFocus` function for every `SortableGameCard`. This broke `React.memo` optimizations (if they existed) or forced re-renders of all N cards even though only 2 cards actually changed state.

📊 Impact: Reduces re-renders from O(N) to O(1) (only the previously focused and newly focused cards re-render). This makes keyboard navigation much smoother, especially for large libraries (hundreds/thousands of games).

🔬 Measurement: Verified by code analysis and successful build (`npm run build`). The changes implement standard React performance patterns (`useCallback`, `useMemo`, `React.memo`) to ensure referential stability of props.

---
*PR created automatically by Jules for task [3784715520017676005](https://jules.google.com/task/3784715520017676005) started by @Lasikiewicz*