### PR TITLE
🔒 Fix unrestricted file execution in app:openPath IPC handler

### DIFF
--- a/main/ipc/appHandlers.ts
+++ b/main/ipc/appHandlers.ts
@@ -450,8 +450,23 @@ export function registerAppIPCHandlers(
             const result = await shell.openPath(userDataPath);
             return { success: result === '', error: result || undefined };
         } else if (existsSync(pathOrType)) {
-            const result = await shell.openPath(pathOrType);
-            return { success: result === '', error: result || undefined };
+            // Security check: Only allow paths within userData or cache directory
+            const resolvedPath = path.resolve(pathOrType);
+            const userDataPath = path.resolve(app.getPath('userData'));
+            const cacheDir = path.resolve(imageCacheService.getCacheDir());
+
+            const allowedPaths = [userDataPath, cacheDir];
+            const isAllowed = allowedPaths.some(allowed =>
+                resolvedPath === allowed || resolvedPath.startsWith(allowed + path.sep)
+            );
+
+            if (isAllowed) {
+                const result = await shell.openPath(pathOrType);
+                return { success: result === '', error: result || undefined };
+            } else {
+                console.warn(`[Security] Blocked access to unsafe path: ${pathOrType}`);
+                return { success: false, error: 'Access denied' };
+            }
         }
         return { success: false, error: 'Path not found' };
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onyx-launcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onyx-launcher",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
This PR addresses a security vulnerability in the `app:openPath` IPC handler where arbitrary file execution was possible.

### Changes
- Modified `main/ipc/appHandlers.ts` to implement strict path validation.
- The handler now resolves the requested path and checks if it is a child of `app.getPath('userData')` or `imageCacheService.getCacheDir()`.
- Unsafe paths are blocked and logged.

### Verification
- Verified manually using a reproduction script `test-security-fix.js` which simulated the validation logic and confirmed that allowed paths work and unsafe paths (e.g. `/etc/passwd`, `../traverse`) are blocked.
- Confirmed that legitimate use cases (opening logs, cache, appData) still work.
- Ran `tsc` to ensure no compilation errors.

---
*PR created automatically by Jules for task [17754988368385849739](https://jules.google.com/task/17754988368385849739) started by @Lasikiewicz*