### PR TITLE
Security: Fix Path Traversal in onyx-local Protocol Handler

### DIFF
--- a/main/main.ts
+++ b/main/main.ts
@@ -1248,11 +1248,7 @@ app.whenReady().then(async () => {
           console.log(`[onyx-local] Could not parse URL: ${urlPath}`);
           console.log(`[onyx-local] Parsed: gameId="${gameId}", imageType="${imageType}"`);
         }
-        // Return 404 for unparseable URLs
-        return new Response(null, {
-          status: 404,
-          headers: { 'Cache-Control': 'no-store' }
-        });
+        // Fall through to fallback logic
       }
 
       // Fallback: try old format decoding
@@ -1364,6 +1360,16 @@ app.whenReady().then(async () => {
 
       // Normalize the path to resolve any .. or . segments
       finalPath = path.normalize(finalPath);
+
+      // SECURITY: Ensure path is within cache directory to prevent traversal attacks
+      if (!finalPath.startsWith(cacheDir)) {
+        console.error(`[onyx-local] ⛔ BLOCKED Path Traversal Attempt: ${finalPath}`);
+        return new Response(null, {
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { 'X-Security-Reason': 'Path Traversal Detected' }
+        });
+      }
 
       // Verify file exists
       if (!existsSync(finalPath)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "onyx-launcher",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "onyx-launcher",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Fixed a security vulnerability in `main/main.ts` where the `onyx-local` protocol handler could potentially allow arbitrary file reads via path traversal in its fallback logic.

The fix involves:
- Removing an early `return` statement that prevented the fallback logic from executing.
- Implementing a security check `!finalPath.startsWith(cacheDir)` to ensure all served files are within the allowed cache directory.
- Returning a 403 Forbidden status for any requests attempting to access files outside the cache directory.

Verified that the build passes and project-specific checks are successful.

---
*PR created automatically by Jules for task [1666609122553910879](https://jules.google.com/task/1666609122553910879) started by @Lasikiewicz*