### PR TITLE
fix(security): prevent command injection in game launcher

### DIFF
--- a/main/LauncherService.test.ts
+++ b/main/LauncherService.test.ts
@@ -1,0 +1,95 @@
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LauncherService } from './LauncherService';
+import { GameStore } from './GameStore';
+
+// Mock electron
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+// Mock child_process
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('child_process', () => ({
+  spawn: spawnMock.mockImplementation(() => ({
+    unref: vi.fn(),
+    on: vi.fn(),
+    pid: 12345,
+  })),
+}));
+
+// Mock GameStore
+const gameStoreMock = {
+  getLibrary: vi.fn(),
+  saveGame: vi.fn(),
+} as unknown as GameStore;
+
+describe('LauncherService Security Test', () => {
+  let launcherService: LauncherService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    launcherService = new LauncherService(gameStoreMock);
+  });
+
+  it('should prevent command injection by not using shell: true', async () => {
+    const gameId = 'custom-game-1';
+    const maliciousGame = {
+      id: gameId,
+      title: 'Malicious Game',
+      exePath: 'echo',
+      launchArgs: '; touch exploited',
+      platform: 'other',
+    };
+
+    (gameStoreMock.getLibrary as any).mockResolvedValue([maliciousGame]);
+
+    await launcherService.launchGame(gameId);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const callArgs = spawnMock.mock.calls[0];
+    const options = callArgs[2];
+
+    // Verify shell is NOT true (FIXED)
+    expect(options.shell).toBeUndefined();
+
+    // Verify arguments passed
+    const command = callArgs[0];
+    const args = callArgs[1];
+
+    // Command should be raw, not quoted
+    expect(command).toBe('echo');
+
+    // Arguments are parsed from launchArgs
+    expect(args).toEqual([';', 'touch', 'exploited']);
+
+    console.log('Security fix confirmed: shell: true is removed');
+  });
+
+  it('should handle quoted exePath by stripping quotes', async () => {
+    const gameId = 'custom-game-2';
+    const quotedGame = {
+      id: gameId,
+      title: 'Quoted Path Game',
+      exePath: '"/path/to/game.exe"',
+      launchArgs: '',
+      platform: 'other',
+    };
+
+    (gameStoreMock.getLibrary as any).mockResolvedValue([quotedGame]);
+
+    await launcherService.launchGame(gameId);
+
+    expect(spawnMock).toHaveBeenCalled();
+    const callArgs = spawnMock.mock.calls[0];
+    const command = callArgs[0];
+
+    // Verify quotes are stripped
+    expect(command).toBe('/path/to/game.exe');
+  });
+});

--- a/main/LauncherService.ts
+++ b/main/LauncherService.ts
@@ -227,13 +227,15 @@ export class LauncherService {
         }
       }
 
-      // Quote the executable path for the shell if it hasn't been already
-      const quotedExePath = game.exePath.startsWith('"') ? game.exePath : `"${game.exePath}"`;
+      // Ensure the executable path is not quoted for spawn (without shell)
+      let exePath = game.exePath;
+      if (exePath.startsWith('"') && exePath.endsWith('"')) {
+        exePath = exePath.slice(1, -1);
+      }
 
-      const child = spawn(quotedExePath, args, {
+      const child = spawn(exePath, args, {
         detached: true,
         stdio: 'ignore',
-        shell: true,  // Required on Windows for paths with spaces
         cwd: workingDir,  // Set working directory
       });
 


### PR DESCRIPTION
This PR fixes a critical Command Injection vulnerability in `LauncherService.ts`.

Previously, `child_process.spawn` was called with `{ shell: true }`, allowing an attacker (via malicious game metadata import) to inject arbitrary shell commands through the `launchArgs` or `exePath`.

The fix involves:
1.  Removing `shell: true` so arguments are passed directly to the executable without shell interpretation.
2.  Adjusting `exePath` handling to strip quotes (which are only needed for shell execution) and pass the raw path to `spawn`.
3.  Adding a regression test `main/LauncherService.test.ts` that mocks `child_process` and verifies that `shell` is not enabled and arguments are passed correctly.

This change ensures that even if `launchArgs` contains malicious characters like `;`, `&`, or `|`, they are treated as literal arguments to the game executable.

---
*PR created automatically by Jules for task [13793827316363287322](https://jules.google.com/task/13793827316363287322) started by @Lasikiewicz*