### PR TITLE
chore: remove unused vars in LibraryListView

### DIFF
--- a/renderer/src/components/LibraryListView.tsx
+++ b/renderer/src/components/LibraryListView.tsx
@@ -106,7 +106,6 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
   };
 
   const displayMode = listViewOptions.displayMode || 'boxart-title';
-  // const showLogoInsteadOfTitle = listViewOptions.showLogos ?? false; // Unused variable
   const titleTextSize = listViewOptions.titleTextSize ?? 18;
   const sectionTextSize = listViewOptions.sectionTextSize ?? 14;
   const tileHeight = listViewOptions.tileHeight ?? listViewSize; // Use tileHeight or fallback to listViewSize
@@ -117,7 +116,6 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
   const showBoxart = displayMode === 'boxart-title';
   const showLogo = displayMode === 'logo-title' || displayMode === 'logo-only';
   const showTitle = displayMode !== 'logo-only';
-  // const showImage = displayMode !== 'title-only'; // Unused variable
 
   const [contextMenu, setContextMenu] = useState<{ game: Game; x: number; y: number } | null>(null);
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);


### PR DESCRIPTION
Removed unused commented-out variables in `renderer/src/components/LibraryListView.tsx`.
 Verified by running the application and checking the Library List View rendering. The changes are purely cosmetic (removing comments) and do not affect functionality.
 Screenshots attached in the verification step.

---
*PR created automatically by Jules for task [1591519480330567146](https://jules.google.com/task/1591519480330567146) started by @Lasikiewicz*