### PR TITLE
Implement Steam Process Checking

### DIFF
--- a/main/GameStore.ts
+++ b/main/GameStore.ts
@@ -1,4 +1,5 @@
 import type Store from 'electron-store';
+import { join } from 'node:path';
 import { SteamGame } from './SteamService.js';
 
 export interface Game {
@@ -239,6 +240,8 @@ export class GameStore {
           bannerUrl = cached.bannerUrl || bannerUrl;
         }
 
+        const installationDirectory = join(steamGame.libraryPath, 'steamapps', 'common', steamGame.installDir);
+
         const updatedGame: Game = {
           ...existingGame, // Preserve all existing fields
           // Only update title if not locked
@@ -247,6 +250,8 @@ export class GameStore {
           bannerUrl,
           // Preserve playtime if it exists (don't overwrite with undefined)
           playtime: existingGame.playtime !== undefined ? existingGame.playtime : undefined,
+          // Update installation directory (using existing if present for backward compatibility, or new one)
+          installationDirectory: existingGame.installationDirectory || installationDirectory,
         };
         gamesMap.set(gameId, updatedGame);
       } else if (!existingGame) {
@@ -261,11 +266,14 @@ export class GameStore {
           bannerUrl = cached.bannerUrl || bannerUrl;
         }
 
+        const installationDirectory = join(steamGame.libraryPath, 'steamapps', 'common', steamGame.installDir);
+
         const game: Game = {
           id: gameId,
           title: steamGame.name,
           platform: 'steam',
           exePath: '', // Steam games don't have direct exe paths, would need to construct from installDir
+          installationDirectory,
           boxArtUrl,
           bannerUrl,
         };

--- a/main/ipc/appHandlers.ts
+++ b/main/ipc/appHandlers.ts
@@ -258,6 +258,95 @@ export function registerAppIPCHandlers(
         }
     });
 
+    // Find PID by checking if process runs from installation directory
+    ipcMain.handle('process:findPidByInstallDir', async (_event, installDir: string) => {
+        if (!installDir) return null;
+
+        const normalizedInstallDir = path.normalize(installDir).toLowerCase();
+
+        return await new Promise<number | null>((resolve) => {
+            try {
+                if (process.platform === 'win32') {
+                    // Windows: Use wmic to get ProcessId and ExecutablePath
+                    execFile('wmic', ['process', 'get', 'ProcessId,ExecutablePath', '/FORMAT:CSV'], (error, stdout) => {
+                        if (error) {
+                            console.error('[ProcessFind] wmic error:', error);
+                            resolve(null);
+                            return;
+                        }
+
+                        const lines = stdout.trim().split('\n');
+                        // Skip header (Node,ExecutablePath,ProcessId)
+                        // CSV format: Node,ExecutablePath,ProcessId
+                        // Note: wmic CSV output often has empty lines or weird formatting
+                        for (const line of lines) {
+                            const trimmed = line.trim();
+                            if (!trimmed || trimmed.startsWith('Node,')) continue;
+
+                            const parts = trimmed.split(',');
+                            if (parts.length >= 3) {
+                                // wmic output might contain commas in path, so careful parsing needed
+                                // Last part is PID, first is Node. Everything in between is path?
+                                // Actually wmic CSV usually puts quotes if needed, or simple commas.
+                                // But ExecutablePath is usually just a path.
+                                // However, safer way: last token is PID.
+                                const pidStr = parts[parts.length - 1];
+                                const pid = parseInt(pidStr, 10);
+
+                                // Reconstruct path (everything between first and last comma)
+                                const exePath = parts.slice(1, parts.length - 1).join(',');
+
+                                if (exePath && !isNaN(pid)) {
+                                    const normalizedPath = path.normalize(exePath).toLowerCase();
+                                    if (normalizedPath.startsWith(normalizedInstallDir)) {
+                                        resolve(pid);
+                                        return;
+                                    }
+                                }
+                            }
+                        }
+                        resolve(null);
+                    });
+                } else {
+                    // POSIX (macOS/Linux): Use ps
+                    execFile('ps', ['-ax', '-o', 'pid,args'], (error, stdout) => {
+                        if (error) {
+                            console.error('[ProcessFind] ps error:', error);
+                            resolve(null);
+                            return;
+                        }
+
+                        const lines = stdout.trim().split('\n');
+                        // Skip header (PID ARGS)
+                        for (let i = 1; i < lines.length; i++) {
+                            const line = lines[i].trim();
+                            if (!line) continue;
+
+                            // Split by whitespace to get PID (first column)
+                            const match = line.match(/^(\d+)\s+(.+)$/);
+                            if (match) {
+                                const pid = parseInt(match[1], 10);
+                                const args = match[2]; // Full command line
+
+                                // Check if command path starts with install dir
+                                // We look at args (command line) which usually starts with executable path
+                                // Or we can look for the path anywhere in the command
+                                if (args.toLowerCase().includes(normalizedInstallDir)) {
+                                    resolve(pid);
+                                    return;
+                                }
+                            }
+                        }
+                        resolve(null);
+                    });
+                }
+            } catch (error) {
+                console.error('[ProcessFind] Unexpected error:', error);
+                resolve(null);
+            }
+        });
+    });
+
     ipcMain.handle('app:minimizeToTray', async () => {
         if (winReference.current) winReference.current.hide();
         return { success: true };

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -135,6 +135,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Process monitoring
   checkProcessExists: (pid: number) => ipcRenderer.invoke('process:checkExists', pid),
+  findPidByInstallDir: (installDir: string) => ipcRenderer.invoke('process:findPidByInstallDir', installDir),
   // API credentials methods
   getAPICredentials: () => ipcRenderer.invoke('api:getCredentials'),
   saveAPICredentials: (credentials: { igdbClientId?: string; igdbClientSecret?: string; steamGridDBApiKey?: string; rawgApiKey?: string; giantBombApiKey?: string }) => ipcRenderer.invoke('api:saveCredentials', credentials),

--- a/renderer/src/App.tsx
+++ b/renderer/src/App.tsx
@@ -1147,12 +1147,29 @@ function App() {
   // Poll for game process for Steam games
   const pollForGameProcess = (gameId: string) => {
     let pollCount = 0;
-    const maxPolls = 30; // Poll for up to 60 seconds (30 * 2s)
+    const maxPolls = 60; // Poll for up to 120 seconds (60 * 2s) to allow for slow launchers/shader compilation
 
     const checkInterval = setInterval(async () => {
       pollCount++;
 
-      // After max polls, assume game closed
+      // Try to find the process ID for this game
+      try {
+        const game = games.find(g => g.id === gameId);
+        // Only check if we have an installation directory (populated by new scans)
+        if (game?.installationDirectory) {
+          const pid = await window.electronAPI.findPidByInstallDir(game.installationDirectory);
+          if (pid) {
+            console.log(`[App] Found process for Steam game ${game.title || gameId}: PID ${pid}`);
+            clearInterval(checkInterval);
+            monitorGameProcess(gameId, pid);
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('[App] Error finding Steam process:', error);
+      }
+
+      // After max polls, assume game closed (or never started/found)
       if (pollCount > maxPolls) {
         clearInterval(checkInterval);
         setRunningGames(prev => {
@@ -1174,9 +1191,6 @@ function App() {
         }
         return;
       }
-
-      // For now, just keep it running for a reasonable time
-      // TODO: Implement actual process checking for Steam games
     }, 2000);
   };
 

--- a/renderer/src/types/game.ts
+++ b/renderer/src/types/game.ts
@@ -361,6 +361,7 @@ declare global {
       getMissingGames: () => Promise<{ success: boolean; games: MissingGame[]; error?: string }>;
       openPath: (pathOrType: string) => Promise<{ success: boolean; error?: string }>;
       checkProcessExists: (pid: number) => Promise<boolean>;
+      findPidByInstallDir: (installDir: string) => Promise<number | null>;
       suspend: {
         getRunningGames: () => Promise<Array<{ gameId: string; title: string; pid: number; status: 'running' | 'suspended'; exePath?: string }>>;
         suspendGame: (gameId: string) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
Implemented actual process checking for Steam games by tracking the game's installation directory and scanning running processes. This replaces the naive timeout-based approach and ensures reliable playtime tracking and game status updates.

Changes:
- `main/GameStore.ts`: Save `installationDirectory` for Steam games.
- `main/ipc/appHandlers.ts`: Added `process:findPidByInstallDir` to find PIDs running from a specific directory.
- `main/preload.ts`: Exposed `findPidByInstallDir`.
- `renderer/src/types/game.ts`: Updated `Window.electronAPI` interface.
- `renderer/src/App.tsx`: Updated `pollForGameProcess` to use the new process check.

---
*PR created automatically by Jules for task [16218904745677765840](https://jules.google.com/task/16218904745677765840) started by @Lasikiewicz*