### PR TITLE
🧪 Test normalizeResolutionKey in UserPreferencesService.ts

### DIFF
--- a/main/UserPreferencesService.test.ts
+++ b/main/UserPreferencesService.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeResolutionKey } from './UserPreferencesService';
+
+describe('normalizeResolutionKey', () => {
+  it('returns default 1080p for undefined', () => {
+    expect(normalizeResolutionKey(undefined)).toBe('1080p');
+  });
+
+  it('returns default 1080p for empty string', () => {
+    expect(normalizeResolutionKey('')).toBe('1080p');
+  });
+
+  it('normalizes 4k correctly', () => {
+    expect(normalizeResolutionKey('4k')).toBe('4K');
+    expect(normalizeResolutionKey('4K')).toBe('4K');
+  });
+
+  it('normalizes 1440p correctly', () => {
+    expect(normalizeResolutionKey('1440p')).toBe('1440p');
+    expect(normalizeResolutionKey('1440P')).toBe('1440p');
+  });
+
+  it('normalizes 720p correctly', () => {
+    expect(normalizeResolutionKey('720p')).toBe('720p');
+    expect(normalizeResolutionKey('720P')).toBe('720p');
+  });
+
+  it('normalizes 1080p correctly', () => {
+    expect(normalizeResolutionKey('1080p')).toBe('1080p');
+    expect(normalizeResolutionKey('1080P')).toBe('1080p');
+  });
+
+  it('returns 1080p for unknown values', () => {
+    expect(normalizeResolutionKey('invalid')).toBe('1080p');
+    expect(normalizeResolutionKey('8k')).toBe('1080p');
+    expect(normalizeResolutionKey('480p')).toBe('1080p');
+  });
+});

--- a/main/UserPreferencesService.ts
+++ b/main/UserPreferencesService.ts
@@ -201,9 +201,17 @@ export interface UserPreferences {
 }
 
 type ViewMode = 'grid' | 'list' | 'logo' | 'carousel' | 'coverflow';
-type ResolutionKey = '720p' | '1080p' | '1440p' | '4K';
+export type ResolutionKey = '720p' | '1080p' | '1440p' | '4K';
 type BaselineDefaults = Record<ResolutionKey, Record<ViewMode, Record<string, any>>>;
 type CustomDefaultsByResolution = Partial<Record<ResolutionKey, Partial<Record<ViewMode, Record<string, any>>>>>;
+
+export function normalizeResolutionKey(value?: string): ResolutionKey {
+  const normalized = (value || '1080p').toLowerCase();
+  if (normalized === '4k') return '4K';
+  if (normalized === '1440p') return '1440p';
+  if (normalized === '720p') return '720p';
+  return '1080p';
+}
 
 interface UserPreferencesSchema {
   preferences: UserPreferences;
@@ -755,14 +763,6 @@ export class UserPreferencesService {
     };
   }
 
-  private normalizeResolutionKey(value?: string): ResolutionKey {
-    const normalized = (value || '1080p').toLowerCase();
-    if (normalized === '4k') return '4K';
-    if (normalized === '1440p') return '1440p';
-    if (normalized === '720p') return '720p';
-    return '1080p';
-  }
-
   /**
    * Detect the current screen resolution category based on the primary display
    */
@@ -1216,7 +1216,7 @@ export class UserPreferencesService {
 
     const store = await this.ensureStore();
     const current = this.normalizeCustomDefaults(store.get('customDefaults', {}));
-    const resolutionKey = this.normalizeResolutionKey(resolution);
+    const resolutionKey = normalizeResolutionKey(resolution);
     const viewModes: ViewMode[] = ['grid', 'list', 'logo', 'carousel', 'coverflow'];
 
     const nextForResolution: Partial<Record<ViewMode, Record<string, any>>> = {
@@ -1241,7 +1241,7 @@ export class UserPreferencesService {
 
   async restoreCustomDefaults(options: { viewMode: ViewMode; scope: 'current' | 'all'; resolution?: string }): Promise<any> {
     const customDefaults = await this.getCustomDefaults();
-    const resolutionKey = this.normalizeResolutionKey(options.resolution);
+    const resolutionKey = normalizeResolutionKey(options.resolution);
     const byResolution = customDefaults[resolutionKey] || {};
 
     if (options.scope === 'all') {


### PR DESCRIPTION
🧪 [testing improvement description]
🎯 **What:** The testing gap addressed
- `normalizeResolutionKey` was a private method in `UserPreferencesService` and was not directly testable.
- Added unit tests for `normalizeResolutionKey` to ensure correct resolution normalization logic.

📊 **Coverage:** What scenarios are now tested
- Default value (undefined/null -> '1080p')
- Valid inputs ('4k', '1440p', '1080p', '720p') with case insensitivity
- Invalid inputs (fallback to '1080p')
- Edge cases (empty string)

✨ **Result:** The improvement in test coverage
- Verified correct behavior of resolution normalization logic through unit tests.
- Improved maintainability by decoupling pure logic from the service class.

---
*PR created automatically by Jules for task [3180600294760341831](https://jules.google.com/task/3180600294760341831) started by @Lasikiewicz*