### PR TITLE
Track per-game settings in saved defaults list

### DIFF
--- a/main/UserPreferencesService.test.ts
+++ b/main/UserPreferencesService.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { UserPreferencesService } from './UserPreferencesService';
+
+// Subclass to mock ensureStore
+class TestUserPreferencesService extends UserPreferencesService {
+  public mockStore: any;
+
+  constructor(mockData: any = {}) {
+    super();
+    this.mockStore = {
+      get: (key: string, def: any) => mockData[key] || def,
+      set: (key: string, val: any) => { mockData[key] = val; },
+      delete: (key: string) => { delete mockData[key]; },
+      has: (key: string) => key in mockData,
+      store: mockData
+    };
+  }
+
+  // @ts-ignore - overriding private/protected method if necessary
+  async ensureStore() {
+    return this.mockStore;
+  }
+}
+
+describe('UserPreferencesService', () => {
+  it('correctly identifies per-game settings in saved defaults', async () => {
+    const mockData = {
+      customDefaults: {
+        '1080p': {
+          grid: {
+            settings: { gridSize: 100 },
+            gamesCustomSettings: { 'game1': { size: 200 } }
+          },
+          list: {
+            settings: { listViewSize: 50 }
+            // No gamesCustomSettings
+          },
+          logo: {
+            settings: { logoSize: 100 },
+            gamesCustomSettings: {} // Empty object
+          }
+        }
+      }
+    };
+
+    const service = new TestUserPreferencesService(mockData);
+    const list = await service.getSavedDefaultsList();
+
+    const gridDefault = list.find(d => d.resolution === '1080p' && d.viewMode === 'grid');
+    const listDefault = list.find(d => d.resolution === '1080p' && d.viewMode === 'list');
+    const logoDefault = list.find(d => d.resolution === '1080p' && d.viewMode === 'logo');
+
+    expect(gridDefault).toBeDefined();
+    expect(gridDefault?.hasPerGameSettings).toBe(true);
+
+    expect(listDefault).toBeDefined();
+    expect(listDefault?.hasPerGameSettings).toBe(false);
+
+    expect(logoDefault).toBeDefined();
+    expect(logoDefault?.hasPerGameSettings).toBe(false);
+  });
+});

--- a/main/UserPreferencesService.ts
+++ b/main/UserPreferencesService.ts
@@ -1291,10 +1291,14 @@ export class UserPreferencesService {
       const byResolution = customDefaults[resolution] || {};
       for (const viewMode of viewModes) {
         if (byResolution[viewMode]) {
+          const modeSettings = byResolution[viewMode] as any;
+          const gameSettings = modeSettings.gamesCustomSettings;
+          const hasPerGameSettings = gameSettings && typeof gameSettings === 'object' && Object.keys(gameSettings).length > 0;
+
           list.push({
             resolution,
             viewMode,
-            hasPerGameSettings: false, // TODO: Track per-game settings per resolution/view
+            hasPerGameSettings: !!hasPerGameSettings,
           });
         }
       }


### PR DESCRIPTION
Resolved TODO in `main/UserPreferencesService.ts` to track whether a saved default configuration includes per-game settings.
- Implemented check for `gamesCustomSettings` object in the saved configuration.
- Added unit test `main/UserPreferencesService.test.ts` to verify the fix.
- Verified with existing validation scripts.

---
*PR created automatically by Jules for task [12553219842728211274](https://jules.google.com/task/12553219842728211274) started by @Lasikiewicz*