### PR TITLE
Implement IGDB fallback for non-Steam providers in MetadataFetcher

### DIFF
--- a/main/MetadataFetcherService.test.ts
+++ b/main/MetadataFetcherService.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MetadataFetcherService } from './MetadataFetcherService.js';
+
+// Mock dependencies
+vi.mock('./IGDBMetadataProvider.js');
+vi.mock('./SteamMetadataProvider.js');
+vi.mock('./RateLimitCoordinator.js', () => ({
+  getRateLimitCoordinator: () => ({ queueRequest: (_: string, fn: () => any) => fn() })
+}));
+vi.mock('./MetadataCache.js', () => ({
+  getMetadataCache: () => ({
+    generateKey: () => 'key',
+    get: () => null,
+    set: () => {}
+  })
+}));
+vi.mock('./MetadataValidator.js', () => ({
+  getMetadataValidator: () => ({ validateMetadata: () => true })
+}));
+vi.mock('./GameMatcher.js', () => ({
+  getGameMatcher: () => ({ stripDemoIndicator: (t: string) => ({ stripped: t, isDemo: false }) })
+}));
+
+describe('MetadataFetcherService', () => {
+  let service: MetadataFetcherService;
+  let mockIGDBProvider: any;
+  let mockSteamProvider: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockIGDBProvider = {
+      isAvailable: vi.fn().mockReturnValue(true),
+      search: vi.fn(),
+      getDescription: vi.fn(),
+      name: 'igdb'
+    };
+
+    mockSteamProvider = {
+      isAvailable: vi.fn().mockReturnValue(true),
+      getDescription: vi.fn(),
+      name: 'steam'
+    };
+
+    // Instantiate service without real services
+    service = new MetadataFetcherService(null, null, null, null, null);
+
+    // Inject mocks manually into private properties
+    (service as any).igdbProvider = mockIGDBProvider;
+    (service as any).steamProvider = mockSteamProvider;
+  });
+
+  describe('searchMetadataOnly', () => {
+    it('should use Steam provider for Steam games', async () => {
+        mockSteamProvider.getDescription.mockResolvedValue({ description: 'Steam Desc', source: 'steam' });
+
+        const result = await service.searchMetadataOnly('123', 'steam', '123', 'Game Title');
+
+        expect(mockSteamProvider.getDescription).toHaveBeenCalledWith('steam-123');
+        expect(result.description).toBe('Steam Desc');
+    });
+
+    it('should use IGDB provider for Epic games via search', async () => {
+        mockIGDBProvider.search.mockResolvedValue([{ id: 456 }]);
+        mockIGDBProvider.getDescription.mockResolvedValue({ description: 'IGDB Desc', source: 'igdb' });
+
+        // This test case expects the fix to be implemented.
+        // Before the fix, this will fail (it will return undefined description).
+        const result = await service.searchMetadataOnly('AppID', 'epic', undefined, 'Epic Game');
+
+        // These assertions are what we EXPECT after the fix
+        expect(mockIGDBProvider.search).toHaveBeenCalledWith('Epic Game', undefined);
+        expect(mockIGDBProvider.getDescription).toHaveBeenCalledWith(456);
+        expect(result.description).toBe('IGDB Desc');
+    });
+
+    it('should use IGDB provider directly if source is igdb', async () => {
+        mockIGDBProvider.getDescription.mockResolvedValue({ description: 'IGDB Direct', source: 'igdb' });
+
+        const result = await service.searchMetadataOnly('igdb-789', 'igdb', undefined, 'Game');
+
+        expect(mockIGDBProvider.getDescription).toHaveBeenCalledWith('igdb-789');
+        expect(result.description).toBe('IGDB Direct');
+    });
+  });
+});

--- a/main/MetadataFetcherService.ts
+++ b/main/MetadataFetcherService.ts
@@ -1068,7 +1068,9 @@ export class MetadataFetcherService {
 
   /**
    * Get metadata only (descriptions, genres, etc.) without fetching artwork/images
-   * Uses Official Store ONLY (Steam for Steam games, etc.)
+   * Strategy:
+   * 1. Official Store API (Steam) for Steam games
+   * 2. IGDB fallback for everything else (Epic, GOG, Xbox, etc.)
    */
   async searchMetadataOnly(providerId: string, providerSource: string, steamAppId?: string, gameTitle?: string): Promise<Partial<GameMetadata>> {
     const descriptionPromises: Promise<GameDescription | null>[] = [];
@@ -1078,9 +1080,31 @@ export class MetadataFetcherService {
       console.log(`[searchMetadataOnly] Fetching from Steam for app ${steamAppId}`);
       descriptionPromises.push(this.steamProvider.getDescription(`steam-${steamAppId}`));
     }
-    // TODO: Add Epic, GOG, Xbox providers here when implemented
-    // if (epicGameId && this.epicProvider?.isAvailable()) { ... }
-    // if (gogGameId && this.gogProvider?.isAvailable()) { ... }
+
+    // IGDB FALLBACK - For non-Steam games (Epic, GOG, Xbox, etc.) or explicitly requested IGDB
+    if (providerSource !== 'steam' && this.igdbProvider?.isAvailable()) {
+      if (providerSource === 'igdb') {
+        // Direct IGDB lookup if the ID is known to be an IGDB ID
+        descriptionPromises.push(this.igdbProvider.getDescription(providerId));
+      } else if (gameTitle) {
+        // For other sources (Epic, GOG, etc.), we don't have a direct ID mapping to IGDB,
+        // so we must search by title to find the corresponding IGDB entry.
+        const igdbPromise = (async () => {
+          try {
+            console.log(`[searchMetadataOnly] Searching IGDB for "${gameTitle}" (source: ${providerSource})`);
+            const results = await this.igdbProvider!.search(gameTitle, steamAppId);
+            if (results.length > 0) {
+              // Use the first match
+              return this.igdbProvider!.getDescription(results[0].id);
+            }
+          } catch (e) {
+            console.warn(`[searchMetadataOnly] IGDB fallback failed for ${gameTitle}:`, e);
+          }
+          return null;
+        })();
+        descriptionPromises.push(igdbPromise);
+      }
+    }
 
     const descriptionResults = await Promise.all(descriptionPromises);
     const mergedDescription = this.mergeDescriptions(descriptionResults, steamAppId);


### PR DESCRIPTION
Refactor MetadataFetcherService to implement IGDB fallback logic for non-Steam providers (Epic, GOG, Xbox, etc.) within `searchMetadataOnly`. This resolves a long-standing TODO and aligns with the project's multi-provider strategy. Added comprehensive tests in `main/MetadataFetcherService.test.ts` using vitest.

---
*PR created automatically by Jules for task [13152580224236774833](https://jules.google.com/task/13152580224236774833) started by @Lasikiewicz*