### PR TITLE
🔒 Fix unrestricted URL opening in app:openExternal

### DIFF
--- a/main/GameMatcher.test.ts
+++ b/main/GameMatcher.test.ts
@@ -46,9 +46,7 @@ describe('GameMatcher', () => {
       id: '100',
       title: 'Test Game',
       source: 'igdb',
-      matchScore: 0,
-      imageUrl: '',
-      provider: 'igdb'
+      boxArtUrl: '',
     };
 
     it('gives high score for exact title match', () => {
@@ -59,7 +57,7 @@ describe('GameMatcher', () => {
 
     it('gives bonus for Steam App ID match', () => {
       const scanned = { ...baseScanned, appId: '12345', source: 'steam' };
-      const candidate = { ...baseCandidate, steamAppId: 12345, source: 'steam' };
+      const candidate = { ...baseCandidate, steamAppId: '12345', source: 'steam' };
 
       const result = matcher.calculateMatchScore(scanned, candidate);
       expect(result.confidence).toBeGreaterThan(0.8); // 0.5 (title) + 0.4 (appId) + 0.1 (source) + 0.1 (provider) -> capped at 1.0
@@ -68,7 +66,7 @@ describe('GameMatcher', () => {
 
     it('penalizes Steam App ID mismatch', () => {
       const scanned = { ...baseScanned, appId: '12345', source: 'steam' };
-      const candidate = { ...baseCandidate, steamAppId: 67890, source: 'steam' };
+      const candidate = { ...baseCandidate, steamAppId: '67890', source: 'steam' };
 
       const result = matcher.calculateMatchScore(scanned, candidate);
       // 0.5 (title) - 0.2 (appId mismatch) + 0.1 (source) + 0.1 (provider) = 0.5

--- a/main/GameStore.ts
+++ b/main/GameStore.ts
@@ -49,6 +49,7 @@ export interface Game {
   hidden?: boolean;
   broken?: boolean;
   notes?: string;
+  modManagerUrl?: string;
   links?: Array<{ name: string; url: string; hidden?: boolean; iconUrl?: string }>;
   actions?: Array<{ name: string; path: string; arguments?: string; workingDir?: string }>;
   scripts?: Array<{ name: string; script: string }>;

--- a/main/LauncherService.ts
+++ b/main/LauncherService.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'child_process';
+import { existsSync } from 'node:fs';
 import { shell } from 'electron';
 import { GameStore, Game } from './GameStore.js';
 
@@ -22,6 +23,51 @@ export class LauncherService {
    * For non-launcher games: executes the .exe file using child_process.spawn
    * Returns PID for non-Steam games for process tracking
    */
+  async launchModManager(gameId: string): Promise<{ success: boolean; error?: string }> {
+    try {
+      const games = await this.gameStore.getLibrary();
+      const game = games.find(g => g.id === gameId);
+
+      if (!game) {
+        return { success: false, error: `Game with ID ${gameId} not found` };
+      }
+
+      if (!game.modManagerUrl) {
+        return { success: false, error: 'Mod Manager not configured for this game' };
+      }
+
+      const urlOrPath = game.modManagerUrl;
+      console.log(`[LauncherService] Launching Mod Manager for ${game.title}: ${urlOrPath}`);
+
+      // Check if it's a web URL
+      try {
+        const parsedUrl = new URL(urlOrPath);
+        if (['http:', 'https:'].includes(parsedUrl.protocol)) {
+          await shell.openExternal(urlOrPath);
+          return { success: true };
+        }
+      } catch {
+        // Not a valid URL, treat as file path
+      }
+
+      // Treat as file path
+      if (existsSync(urlOrPath)) {
+        // Use shell.openPath to launch the executable or open the file
+        const error = await shell.openPath(urlOrPath);
+        if (error) {
+          return { success: false, error: `Failed to open Mod Manager: ${error}` };
+        }
+        return { success: true };
+      }
+
+      return { success: false, error: 'Mod Manager path not found' };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+      console.error('Error launching Mod Manager:', errorMessage);
+      return { success: false, error: errorMessage };
+    }
+  }
+
   async launchGame(gameId: string): Promise<{ success: boolean; error?: string; pid?: number }> {
     try {
       const games = await this.gameStore.getLibrary();

--- a/main/ipc/appHandlers.ts
+++ b/main/ipc/appHandlers.ts
@@ -427,8 +427,19 @@ export function registerAppIPCHandlers(
     };
 
     ipcMain.handle('app:openExternal', async (_event, url) => {
-        await shell.openExternal(url);
-        return { success: true };
+        try {
+            const parsedUrl = new URL(url);
+            const allowedProtocols = ['http:', 'https:', 'mailto:'];
+            if (allowedProtocols.includes(parsedUrl.protocol)) {
+                await shell.openExternal(url);
+                return { success: true };
+            }
+            console.warn(`[Security] Blocked access to unsafe protocol: ${parsedUrl.protocol}`);
+            return { success: false, error: 'Protocol not allowed' };
+        } catch (error) {
+            console.error('[Security] Invalid URL passed to openExternal:', url);
+            return { success: false, error: 'Invalid URL' };
+        }
     });
 
     ipcMain.handle('app:openPath', async (_event, pathOrType) => {

--- a/main/ipc/launcherHandlers.ts
+++ b/main/ipc/launcherHandlers.ts
@@ -27,6 +27,16 @@ export function registerLauncherIPCHandlers(
         }
     });
 
+    ipcMain.handle('launcher:launchModManager', async (_event, gameId: string) => {
+        try {
+            console.log(`[Launcher] Launching Mod Manager for game: ${gameId}`);
+            return await launcherService.launchModManager(gameId);
+        } catch (error) {
+            console.error('Error in launcher:launchModManager handler:', error);
+            return { success: false, error: error instanceof Error ? error.message : 'Unknown error' };
+        }
+    });
+
     ipcMain.handle('launcher:detectAll', async () => {
         try {
             console.log('[Launcher] Detecting all launchers...');

--- a/main/preload.ts
+++ b/main/preload.ts
@@ -59,6 +59,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   fetchMetadataOnlyByProviderId: (gameId: string, providerId: string, providerSource: string) => ipcRenderer.invoke('metadata:fetchMetadataOnlyByProviderId', gameId, providerId, providerSource),
   // Launcher methods
   launchGame: (gameId: string) => ipcRenderer.invoke('launcher:launchGame', gameId),
+  launchModManager: (gameId: string) => ipcRenderer.invoke('launcher:launchModManager', gameId),
   // App config methods
   getAppConfigs: () => ipcRenderer.invoke('appConfig:getAll'),
   getAppConfig: (appId: string) => ipcRenderer.invoke('appConfig:get', appId),

--- a/renderer/src/components/BottomBar.tsx
+++ b/renderer/src/components/BottomBar.tsx
@@ -48,7 +48,7 @@ export const BottomBar: React.FC<BottomBarProps> = ({ game, onPlay, onFavorite, 
               onClick={async () => {
                 if (game.modManagerUrl) {
                   try {
-                    await window.electronAPI.openExternal(game.modManagerUrl);
+                    await window.electronAPI.launchModManager(game.id);
                   } catch (err) {
                     console.error('Error opening mod manager:', err);
                   }

--- a/renderer/src/components/GameContextMenu.tsx
+++ b/renderer/src/components/GameContextMenu.tsx
@@ -112,7 +112,7 @@ export const GameContextMenu: React.FC<GameContextMenuProps> = ({
   const handleModManager = async () => {
     if (game.modManagerUrl) {
       try {
-        await window.electronAPI.openExternal(game.modManagerUrl);
+        await window.electronAPI.launchModManager(game.id);
       } catch (err) {
         console.error('Error opening mod manager:', err);
       }

--- a/renderer/src/components/GameDetailsPanel.tsx
+++ b/renderer/src/components/GameDetailsPanel.tsx
@@ -926,7 +926,7 @@ export const GameDetailsPanel: React.FC<GameDetailsPanelProps> = ({
                     onClick={async () => {
                       if (game.modManagerUrl) {
                         try {
-                          await window.electronAPI.openExternal(game.modManagerUrl);
+                    await window.electronAPI.launchModManager(game.id);
                         } catch (err) {
                           console.error('Error opening mod manager:', err);
                         }

--- a/renderer/src/components/LibraryCarousel.tsx
+++ b/renderer/src/components/LibraryCarousel.tsx
@@ -409,7 +409,7 @@ export const LibraryCarousel: React.FC<LibraryCarouselProps> = ({
                     onClick={async () => {
                       if (selectedGame.modManagerUrl) {
                         try {
-                          await window.electronAPI.openExternal(selectedGame.modManagerUrl);
+                          await window.electronAPI.launchModManager(selectedGame.id);
                         } catch (err) {
                           console.error('Error opening mod manager:', err);
                         }

--- a/renderer/src/components/LibraryCoverFlow.tsx
+++ b/renderer/src/components/LibraryCoverFlow.tsx
@@ -301,7 +301,7 @@ export const LibraryCoverFlow: React.FC<LibraryCoverFlowProps> = ({
               type="button"
               onClick={async (e) => {
                 e.stopPropagation();
-                if (selectedGame.modManagerUrl) await window.electronAPI?.openExternal(selectedGame.modManagerUrl);
+                if (selectedGame.modManagerUrl) await window.electronAPI?.launchModManager(selectedGame.id);
               }}
               className="px-3 py-1.5 rounded text-white text-sm font-medium shadow-lg hover:opacity-90 transition-opacity"
               style={{ backgroundColor: modColor }}

--- a/renderer/src/types/game.ts
+++ b/renderer/src/types/game.ts
@@ -295,6 +295,7 @@ declare global {
       fetchAndUpdateByProviderId: (gameId: string, providerId: string, providerSource: string) => Promise<{ success: boolean; error?: string; metadata: GameMetadata | null }>;
       fetchMetadataOnlyByProviderId: (gameId: string, providerId: string, providerSource: string) => Promise<{ success: boolean; error?: string; metadata: Partial<GameMetadata> | null }>;
       launchGame: (gameId: string) => Promise<{ success: boolean; error?: string; pid?: number }>;
+      launchModManager: (gameId: string) => Promise<{ success: boolean; error?: string }>;
       getAppConfigs: () => Promise<Record<string, { id: string; name: string; enabled: boolean; path: string; autoAdd?: boolean; syncPlaytime?: boolean }>>;
       getAppConfig: (appId: string) => Promise<{ id: string; name: string; enabled: boolean; path: string; autoAdd?: boolean; syncPlaytime?: boolean } | null>;
       saveAppConfig: (config: { id: string; name: string; enabled: boolean; path: string; autoAdd?: boolean }) => Promise<{ success: boolean; error?: string }>;


### PR DESCRIPTION
This PR fixes a security vulnerability where `app:openExternal` allowed opening arbitrary protocols, including `file:`. 

**Changes:**
1.  **Strict Protocol Validation:** `app:openExternal` now throws an error if the URL protocol is not one of `['http:', 'https:', 'mailto:']`.
2.  **Dedicated Mod Manager Handler:** A new IPC handler `launcher:launchModManager` was added. This handler looks up the game by ID from the `GameStore` and opens the configured `modManagerUrl`. This ensures that the renderer cannot pass arbitrary file paths to be executed, only pre-configured paths associated with games.
3.  **Renderer Updates:** Updated all components (`LibraryCarousel`, `LibraryCoverFlow`, `GameContextMenu`, `BottomBar`, `GameDetailsPanel`) to use the new handler.
4.  **Type Fixes:** Added `modManagerUrl` to the backend `Game` interface and fixed existing type errors in `GameMatcher.test.ts` to ensure a clean build.

**Risk:**
Previously, a compromised renderer or malicious input could use `app:openExternal` to execute arbitrary local files. The new approach restricts this capability while maintaining the "Mod Manager" feature functionality.

---
*PR created automatically by Jules for task [3288370958738217585](https://jules.google.com/task/3288370958738217585) started by @Lasikiewicz*