### PR TITLE
🧹 Remove leftover empty line in OnyxSettingsModal.tsx

### DIFF
--- a/renderer/src/components/OnyxSettingsModal.tsx
+++ b/renderer/src/components/OnyxSettingsModal.tsx
@@ -153,7 +153,6 @@ export const OnyxSettingsModal: React.FC<OnyxSettingsModalProps> = ({
     giantBombApiKey: '',
   });
   const [activeAPITab, setActiveAPITab] = useState<APITabType>('steamgriddb');
-
   const [apps, setApps] = useState<AppConfig[]>([]);
   const [isLoadingApps, setIsLoadingApps] = useState(false);
   const [scanningAppId, setScanningAppId] = useState<string | null>(null);


### PR DESCRIPTION
The task requested the removal of commented-out dead code in `renderer/src/components/OnyxSettingsModal.tsx`. Upon inspection, the specified code was not present, but an empty line existed in its place. This change removes that empty line to clean up the file. Code health verified with `tsc`.

---
*PR created automatically by Jules for task [14442030085324752449](https://jules.google.com/task/14442030085324752449) started by @Lasikiewicz*