### PR TITLE
⚡ Optimize LibraryCarousel rendering with virtualization

### DIFF
--- a/renderer/src/components/LibraryCarousel.tsx
+++ b/renderer/src/components/LibraryCarousel.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { Game } from '../types/game';
 import { GameContextMenu } from './GameContextMenu';
 import { getContrastingTextColor } from '../utils/colorUtils';
+import { calculateVirtualWindow, calculateLeftSpacerWidth } from '../utils/virtualization';
 
 interface LibraryCarouselProps {
   games: Game[];
@@ -156,6 +157,23 @@ export const LibraryCarousel: React.FC<LibraryCarouselProps> = ({
   React.useEffect(() => {
     setCarouselOffset(calculateOffset(validSelectedIndex));
   }, [validSelectedIndex]);
+
+  // Virtualization calculations
+  const { startIndex, endIndex } = React.useMemo(() => {
+    // Buffer size depends on screen width, but using safe defaults covers most cases
+    // 20 items * 100px = 2000px, enough for most screens
+    const bufferLeft = 20;
+    const bufferRight = 30;
+    return calculateVirtualWindow(validSelectedIndex, games.length, { bufferLeft, bufferRight });
+  }, [validSelectedIndex, games.length]);
+
+  const leftSpacerWidth = React.useMemo(() => {
+    return calculateLeftSpacerWidth(startIndex, baseGameWidth, gameTilePadding);
+  }, [startIndex, baseGameWidth, gameTilePadding]);
+
+  const visibleGames = React.useMemo(() => {
+    return games.slice(startIndex, endIndex);
+  }, [games, startIndex, endIndex]);
 
   // Handle keyboard navigation
   React.useEffect(() => {
@@ -495,8 +513,21 @@ export const LibraryCarousel: React.FC<LibraryCarouselProps> = ({
               transform: `translateX(${carouselOffset}px)`,
             }}
           >
-            {/* Render all games in sequence */}
-            {games.map((game, index) => {
+            {/* Spacer for virtualized items */}
+            {startIndex > 0 && (
+              <div
+                style={{
+                  width: `${leftSpacerWidth}px`,
+                  flexShrink: 0,
+                  height: `${baseGameHeight}px`, // Maintain height to prevent layout shifts
+                  // Margins are not needed as spacer calculation assumes 0 margins, and gap handles spacing
+                }}
+              />
+            )}
+
+            {/* Render visible games */}
+            {visibleGames.map((game, i) => {
+              const index = startIndex + i;
               const isSelected = index === validSelectedIndex;
 
               return (

--- a/renderer/src/utils/virtualization.ts
+++ b/renderer/src/utils/virtualization.ts
@@ -1,0 +1,39 @@
+
+export function calculateVirtualWindow(
+  selectedIndex: number,
+  totalItems: number,
+  options: { bufferLeft: number; bufferRight: number }
+) {
+  const { bufferLeft, bufferRight } = options;
+
+  const startIndex = Math.max(0, selectedIndex - bufferLeft);
+  const endIndex = Math.min(totalItems, selectedIndex + bufferRight);
+
+  return { startIndex, endIndex };
+}
+
+export function calculateLeftSpacerWidth(
+  startIndex: number,
+  itemWidth: number,
+  itemPadding: number
+) {
+  if (startIndex <= 0) return 0;
+
+  // Stride calculation based on LibraryCarousel.tsx layout:
+  // Each item occupies: width + marginLeft + marginRight.
+  // Plus the flex container gap between items.
+  // marginLeft = itemPadding
+  // marginRight = itemPadding
+  // gap = itemPadding
+
+  const gap = itemPadding;
+  const stride = itemWidth + 2 * itemPadding + gap;
+
+  // The item at `startIndex` should visually start at `startIndex * stride`.
+  // With a spacer, it starts at `width(Spacer) + margin(Spacer) + gap`.
+  // We assume spacer has 0 margins for simplicity.
+  // So `width(Spacer) + gap = startIndex * stride`.
+  // `width(Spacer) = startIndex * stride - gap`.
+
+  return startIndex * stride - gap;
+}

--- a/scripts/test-virtualization.ts
+++ b/scripts/test-virtualization.ts
@@ -1,0 +1,55 @@
+import { calculateVirtualWindow, calculateLeftSpacerWidth } from '../renderer/src/utils/virtualization';
+
+// Simple assert helper
+function assertEqual(actual: any, expected: any, message: string) {
+  if (actual !== expected) {
+    throw new Error(`Assertion failed: ${message}. Expected ${expected}, got ${actual}`);
+  }
+}
+
+const totalItems = 100;
+const bufferLeft = 10;
+const bufferRight = 10;
+const itemWidth = 100;
+const itemPadding = 1;
+
+// Case 1: Start of list
+{
+  const selectedIndex = 5;
+  const { startIndex, endIndex } = calculateVirtualWindow(selectedIndex, totalItems, { bufferLeft, bufferRight });
+  assertEqual(startIndex, 0, 'Case 1 startIndex');
+  assertEqual(endIndex, 15, 'Case 1 endIndex');
+
+  const spacer = calculateLeftSpacerWidth(startIndex, itemWidth, itemPadding);
+  assertEqual(spacer, 0, 'Case 1 spacer');
+  console.log('Case 1 passed');
+}
+
+// Case 2: Middle of list
+{
+  const selectedIndex = 50;
+  const { startIndex, endIndex } = calculateVirtualWindow(selectedIndex, totalItems, { bufferLeft, bufferRight });
+  assertEqual(startIndex, 40, 'Case 2 startIndex');
+  assertEqual(endIndex, 60, 'Case 2 endIndex');
+
+  const spacer = calculateLeftSpacerWidth(startIndex, itemWidth, itemPadding);
+  // Stride = 100 + 2*1 + 1 = 103.
+  // Spacer = 40 * 103 - 1 = 4120 - 1 = 4119.
+  assertEqual(spacer, 4119, 'Case 2 spacer');
+  console.log('Case 2 passed');
+}
+
+// Case 3: End of list
+{
+  const selectedIndex = 95;
+  const { startIndex, endIndex } = calculateVirtualWindow(selectedIndex, totalItems, { bufferLeft, bufferRight });
+  assertEqual(startIndex, 85, 'Case 3 startIndex');
+  assertEqual(endIndex, 100, 'Case 3 endIndex');
+
+  const spacer = calculateLeftSpacerWidth(startIndex, itemWidth, itemPadding);
+  // Spacer = 85 * 103 - 1 = 8755 - 1 = 8754.
+  assertEqual(spacer, 8754, 'Case 3 spacer');
+  console.log('Case 3 passed');
+}
+
+console.log('All tests passed');


### PR DESCRIPTION
Implemented virtualization in the `LibraryCarousel` component to improve rendering performance for large libraries. Instead of rendering all game items, only a visible window of items (plus a buffer) is rendered. The layout is preserved using a calculated spacer element.

Details:
- Added `calculateVirtualWindow` and `calculateLeftSpacerWidth` utilities in `renderer/src/utils/virtualization.ts`.
- Updated `LibraryCarousel.tsx` to use these utilities and slice the `games` array before rendering.
- Added `scripts/test-virtualization.ts` to verify the logic.
- Performance impact: Reduces DOM node count from O(N) to O(1) (rendering ~30-50 items regardless of library size), significantly improving render times and memory usage for large libraries.

---
*PR created automatically by Jules for task [16530588628176220320](https://jules.google.com/task/16530588628176220320) started by @Lasikiewicz*