### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure protocol handling in LauncherService

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-18 - Unrestricted openExternal
+**Vulnerability:** `LauncherService.launchModManager` used `modManagerUrl.includes('://')` to detect URLs, allowing unsafe protocols like `file://` to be passed to `shell.openExternal`.
+**Learning:** `shell.openExternal` is dangerous with untrusted protocols.
+**Prevention:** Use `new URL()` to parse and validate `protocol` against an explicit whitelist (e.g., `http:`, `https:`).

--- a/main/LauncherService.ts
+++ b/main/LauncherService.ts
@@ -293,12 +293,15 @@ export class LauncherService {
 
       // Try as URL first
       try {
-        if (modManagerUrl.startsWith('http://') || modManagerUrl.startsWith('https://') || modManagerUrl.includes('://')) {
+        // SECURITY: Only allow http and https protocols for openExternal to prevent
+        // arbitrary code execution via file:// or other dangerous schemes.
+        const parsedUrl = new URL(modManagerUrl);
+        if (parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:') {
           await shell.openExternal(modManagerUrl);
           return { success: true };
         }
       } catch (e) {
-        // Not a URL, continue to file path check
+        // Not a valid URL, or not http/https - continue to file path check
       }
 
       const { existsSync } = require('node:fs');


### PR DESCRIPTION
This PR addresses a critical security vulnerability in `LauncherService.launchModManager` where user-controlled URLs could bypass safety checks and be executed via `shell.openExternal`.

**Changes:**
- Replaced `modManagerUrl.includes('://')` with strict `URL` parsing and protocol whitelist (`http:`, `https:`).
- Added Sentinel journal entry documenting the vulnerability and learning.

**Verification:**
- Verified with `verify_logic.ts` that `file://` and local paths are correctly rejected by the new logic, ensuring they fall through to safe file path handling logic (`shell.openPath`).
- Ran existing unit tests (`pnpm test`) to ensure no regressions.

---
*PR created automatically by Jules for task [5786485038149601282](https://jules.google.com/task/5786485038149601282) started by @Lasikiewicz*