### PR TITLE
Shield: Centralize and enforce secure URL protocol validation

### DIFF
--- a/main/LauncherService.ts
+++ b/main/LauncherService.ts
@@ -2,6 +2,7 @@ import { spawn, execFile } from 'child_process';
 import { dirname } from 'path';
 import { shell } from 'electron';
 import { GameStore, Game } from './GameStore.js';
+import { isSafeExternalUrl } from './SecurityUtils.js';
 
 export class LauncherService {
   private gameStore: GameStore;
@@ -301,7 +302,7 @@ export class LauncherService {
 
       // Try as URL first
       try {
-        if (modManagerUrl.startsWith('http://') || modManagerUrl.startsWith('https://') || modManagerUrl.includes('://')) {
+        if (isSafeExternalUrl(modManagerUrl)) {
           await shell.openExternal(modManagerUrl);
           return { success: true };
         }

--- a/main/SecurityUtils.test.ts
+++ b/main/SecurityUtils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { isSafeExternalUrl } from './SecurityUtils.js';
+
+describe('SecurityUtils', () => {
+    describe('isSafeExternalUrl', () => {
+        it('should allow http and https URLs', () => {
+            expect(isSafeExternalUrl('http://example.com')).toBe(true);
+            expect(isSafeExternalUrl('https://example.com/foo/bar')).toBe(true);
+        });
+
+        it('should allow known launcher protocols', () => {
+            expect(isSafeExternalUrl('steam://rungameid/123')).toBe(true);
+            expect(isSafeExternalUrl('epic://test')).toBe(true);
+            expect(isSafeExternalUrl('goggalaxy://launchGame/123')).toBe(true);
+            expect(isSafeExternalUrl('uplay://launch/123')).toBe(true);
+            expect(isSafeExternalUrl('origin://game/launch')).toBe(true);
+            expect(isSafeExternalUrl('origin2://game/launch')).toBe(true);
+            expect(isSafeExternalUrl('battlenet://launch')).toBe(true);
+            expect(isSafeExternalUrl('com.epicgames.launcher://apps/test')).toBe(true);
+            expect(isSafeExternalUrl('xbox://test')).toBe(true);
+            expect(isSafeExternalUrl('ms-windows-store://pdp/?ProductId=9WZDNCRFHVJL')).toBe(true);
+        });
+
+        it('should allow mod manager protocols', () => {
+            expect(isSafeExternalUrl('nexusm://skyrim/mods/123')).toBe(true);
+            expect(isSafeExternalUrl('vortex://test')).toBe(true);
+        });
+
+        it('should allow mailto links', () => {
+            expect(isSafeExternalUrl('mailto:user@example.com')).toBe(true);
+        });
+
+        it('should reject javascript: URLs', () => {
+            expect(isSafeExternalUrl('javascript:alert(1)')).toBe(false);
+        });
+
+        it('should reject vbscript: URLs', () => {
+            expect(isSafeExternalUrl('vbscript:msgbox("hello")')).toBe(false);
+        });
+
+        it('should reject file: URLs', () => {
+            expect(isSafeExternalUrl('file:///C:/Windows/System32/calc.exe')).toBe(false);
+        });
+
+        it('should reject unknown protocols', () => {
+            expect(isSafeExternalUrl('unknown://test')).toBe(false);
+            expect(isSafeExternalUrl('ftp://example.com')).toBe(false);
+        });
+
+        it('should reject invalid URLs', () => {
+            expect(isSafeExternalUrl('not-a-url')).toBe(false);
+            expect(isSafeExternalUrl('')).toBe(false);
+        });
+    });
+});

--- a/main/SecurityUtils.ts
+++ b/main/SecurityUtils.ts
@@ -1,0 +1,38 @@
+import { URL } from 'node:url';
+
+/**
+ * List of protocols that are considered safe to open via shell.openExternal
+ */
+export const ALLOWED_EXTERNAL_PROTOCOLS = [
+  'http:',
+  'https:',
+  'steam:',
+  'epic:',
+  'goggalaxy:',
+  'uplay:',
+  'origin:',
+  'origin2:',
+  'com.epicgames.launcher:',
+  'battlenet:',
+  'xbox:',
+  'ms-windows-store:',
+  'nexusm:', // Nexus Mods
+  'vortex:', // Vortex Mod Manager
+  'mailto:', // Standard mailto links
+];
+
+/**
+ * Validates if a URL uses a safe protocol allowed for external opening.
+ *
+ * @param url The URL string to validate
+ * @returns true if the URL uses a safe protocol, false otherwise
+ */
+export function isSafeExternalUrl(url: string): boolean {
+  try {
+    const parsedUrl = new URL(url);
+    return ALLOWED_EXTERNAL_PROTOCOLS.includes(parsedUrl.protocol);
+  } catch {
+    // URL parsing failed, considered unsafe
+    return false;
+  }
+}

--- a/main/ipc/appHandlers.ts
+++ b/main/ipc/appHandlers.ts
@@ -12,6 +12,7 @@ import { APICredentialsService } from '../APICredentialsService.js';
 import { SteamAuthService } from '../SteamAuthService.js';
 import { BugReportService } from '../BugReportService.js';
 import { checkForUpdates as doCheckForUpdates, downloadUpdate as doDownloadUpdate, quitAndInstall as doQuitAndInstall } from '../AppUpdateService.js';
+import { isSafeExternalUrl } from '../SecurityUtils.js';
 
 const GITHUB_OWNER = 'Lasikiewicz';
 const GITHUB_REPO = 'onyx';
@@ -471,21 +472,7 @@ export function registerAppIPCHandlers(
 
     ipcMain.handle('app:openExternal', async (_event, url) => {
         try {
-            const parsedUrl = new URL(url);
-            const allowedProtocols = [
-                'http:',
-                'https:',
-                'steam:',
-                'epic:',
-                'goggalaxy:',
-                'uplay:',
-                'origin:',
-                'origin2:',
-                'com.epicgames.launcher:',
-                'battlenet:'
-            ];
-
-            if (!allowedProtocols.includes(parsedUrl.protocol)) {
+            if (!isSafeExternalUrl(url)) {
                 console.warn(`[Security] Blocked attempt to open unsafe external URL: ${url}`);
                 return { success: false, error: 'Disallowed protocol' };
             }


### PR DESCRIPTION
This PR enhances the security of the application by centralizing and enforcing a strict whitelist for external URL protocols.

**Changes:**
1.  **New Security Utility:** Created `main/SecurityUtils.ts` which exports `ALLOWED_EXTERNAL_PROTOCOLS` and `isSafeExternalUrl(url)`. This utility validates that a URL's protocol is one of the approved safe schemes (e.g., `http:`, `https:`, `steam:`, `nexusm:`, `vortex:`).
2.  **App Handlers Update:** Refactored `main/ipc/appHandlers.ts` to use `isSafeExternalUrl` in the `app:openExternal` IPC handler, replacing the inline allowed list and ensuring consistent validation logic.
3.  **Launcher Service Update:** Updated `main/LauncherService.ts` to use `isSafeExternalUrl` in the `launchModManager` method. Previously, this method used a permissive check (`.includes('://')`), which could potentially allow dangerous protocols (e.g., `javascript:`, `vbscript:`) if a malicious URL was provided in a game configuration.
4.  **Testing:** Added `main/SecurityUtils.test.ts` with comprehensive unit tests to verify that safe protocols are allowed and unsafe/malicious ones are rejected.

**Security Impact:**
- Prevents potential command execution or XSS vectors via `shell.openExternal` by ensuring only trusted protocols are handled.
- Mitigates risks associated with user-imported game configurations containing malicious mod manager URLs.

**Verification:**
- `npm run test` passes, verifying the new security utility logic.
- `npm run build` passes, ensuring no type errors.

---
*PR created automatically by Jules for task [9686832844110844240](https://jules.google.com/task/9686832844110844240) started by @Lasikiewicz*