### PR TITLE
⚡ Bolt: GameFilteringService redundant allocation optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - [Avoid Redundant Allocations in Scanning Services]
+**Learning:** In highly repetitive scanning services like `GameFilteringService`, large arrays and Sets (like `KNOWN_PUBLISHERS` or `NON_GAME_EXECUTABLES`) must be defined as `private static readonly` properties. Returning them from methods inside the scanning loop causes thousands of redundant object allocations during directory tree traversals, significantly impacting garbage collection and performance.
+**Action:** Always verify that constant lists and regex patterns used in high-frequency validation loops are hoisted to static readonly properties or at least out of the method scope, especially in file system scanners.

--- a/main/GameFilteringService.ts
+++ b/main/GameFilteringService.ts
@@ -8,126 +8,139 @@ import { readdirSync } from 'node:fs';
  */
 export class GameFilteringService {
   /**
-   * Get known game publishers across all platforms
+   * Known game publishers across all platforms
    * Used to whitelist games from established publishers
+   * ⚡ BOLT: Hoisted to static readonly to prevent redundant object allocations during frequent directory scans
    */
-  private getKnownGamePublishers(): Set<string> {
-    return new Set([
-      // AAA Publishers
-      'ea', 'activision', 'ubisoft', '2k', 'square', 'rockstar', 'bethesda', 'capcom',
-      'bandai', 'konami', 'sega', 'disney', 'warner', 'paramount', 'sony',
-      'microsoft', 'xbox', 'obsidian', 'ninja', 'rare', 'inxile', 'playground',
-      'coalition', 'remedy', 'compulsion', 'sloclap', 'astragon', 'blizzard',
-    ]);
-  }
+  private static readonly KNOWN_PUBLISHERS: ReadonlySet<string> = new Set([
+    // AAA Publishers
+    'ea', 'activision', 'ubisoft', '2k', 'square', 'rockstar', 'bethesda', 'capcom',
+    'bandai', 'konami', 'sega', 'disney', 'warner', 'paramount', 'sony',
+    'microsoft', 'xbox', 'obsidian', 'ninja', 'rare', 'inxile', 'playground',
+    'coalition', 'remedy', 'compulsion', 'sloclap', 'astragon', 'blizzard',
+  ]);
 
   /**
    * System app prefixes/folders to exclude
    */
-  private getSystemAppPatterns(): string[] {
-    return [
-      // Windows system apps
-      'microsoft.windows', 'microsoft.office', 'microsoft.edge', 'microsoft.store',
-      'microsoft.skype', 'microsoft.msn', 'microsoft.weather', 'microsoft.photos',
-      'microsoft.camera', 'microsoft.clock', 'microsoft.calculator',
-      'microsoft.messaging', 'microsoft.notes', 'microsoft.mail', 'microsoft.people',
-      'microsoft.maps', 'microsoft.net', 'microsoft.vclibs', 'microsoft.ui.xaml',
-      'microsoft.advertising', 'microsoft.services.store', 'microsoft.gamingapp',
-      'microsoft.gamingservices', 'microsoft.xboxapp', 'microsoft.xbox',
+  private static readonly SYSTEM_APP_PATTERNS: readonly string[] = [
+    // Windows system apps
+    'microsoft.windows', 'microsoft.office', 'microsoft.edge', 'microsoft.store',
+    'microsoft.skype', 'microsoft.msn', 'microsoft.weather', 'microsoft.photos',
+    'microsoft.camera', 'microsoft.clock', 'microsoft.calculator',
+    'microsoft.messaging', 'microsoft.notes', 'microsoft.mail', 'microsoft.people',
+    'microsoft.maps', 'microsoft.net', 'microsoft.vclibs', 'microsoft.ui.xaml',
+    'microsoft.advertising', 'microsoft.services.store', 'microsoft.gamingapp',
+    'microsoft.gamingservices', 'microsoft.xboxapp', 'microsoft.xbox',
 
-      // Third-party utilities
-      'adobe', 'autodesk', 'jetbrains', 'sublimetext', 'vscode', 'visualstudio',
-      'python', 'nodejs', 'git', 'docker', 'vlc', 'audacity', 'ffmpeg',
-    ];
-  }
+    // Third-party utilities
+    'adobe', 'autodesk', 'jetbrains', 'sublimetext', 'vscode', 'visualstudio',
+    'python', 'nodejs', 'git', 'docker', 'vlc', 'audacity', 'ffmpeg',
+  ];
 
   /**
    * Non-game keywords (in app name, folder name, or exe name)
    */
-  private getNonGameKeywords(): string[] {
-    return [
-      // Media/Entertainment
-      'music', 'video', 'tv', 'movie', 'media', 'photo', 'camera', 'photoeditor',
-      'gallery', 'clipchamp', 'paint', 'editor', 'viewer', 'player',
+  private static readonly NON_GAME_KEYWORDS: readonly string[] = [
+    // Media/Entertainment
+    'music', 'video', 'tv', 'movie', 'media', 'photo', 'camera', 'photoeditor',
+    'gallery', 'clipchamp', 'paint', 'editor', 'viewer', 'player',
 
-      // System/Tools
-      'settings', 'config', 'update', 'updater', 'installer', 'runtime', 'driver',
-      'service', 'services', 'keyboard', 'language', 'voice', 'assistant', 'copilot',
-      'search', 'mail', 'outlook', 'calendar', 'news', 'weather', 'maps', 'clock',
-      'calculator', 'store', 'browser', 'onedrive', 'onenote', 'teams', 'office',
-      'word', 'excel', 'powerpoint', 'access', 'publisher', 'project',
+    // System/Tools
+    'settings', 'config', 'update', 'updater', 'installer', 'runtime', 'driver',
+    'service', 'services', 'keyboard', 'language', 'voice', 'assistant', 'copilot',
+    'search', 'mail', 'outlook', 'calendar', 'news', 'weather', 'maps', 'clock',
+    'calculator', 'store', 'browser', 'onedrive', 'onenote', 'teams', 'office',
+    'word', 'excel', 'powerpoint', 'access', 'publisher', 'project',
 
-      // Support/Admin
-      'support', 'help', 'feedback', 'repair', 'firmware', 'backup', 'sync',
-      'family', 'security', 'defender', 'antivirus', 'malware', 'control panel',
-      'device manager', 'task manager', 'registry', 'powershell', 'command',
+    // Support/Admin
+    'support', 'help', 'feedback', 'repair', 'firmware', 'backup', 'sync',
+    'family', 'security', 'defender', 'antivirus', 'malware', 'control panel',
+    'device manager', 'task manager', 'registry', 'powershell', 'command',
 
-      // Hardware/Drivers
-      'intel', 'nvidia', 'amd', 'realtek', 'audio', 'driver', 'chipset',
-      'graphics', 'network', 'wifi', 'bluetooth', 'usb',
+    // Hardware/Drivers
+    'intel', 'nvidia', 'amd', 'realtek', 'audio', 'driver', 'chipset',
+    'graphics', 'network', 'wifi', 'bluetooth', 'usb',
 
-      // Hardware Manufacturer Utilities
-      'lenovo', 'dell', 'hp', 'asus', 'msi', 'acer', 'razer', 'corsair',
-      'logitech', 'steelseries', 'apple', 'google',
+    // Hardware Manufacturer Utilities
+    'lenovo', 'dell', 'hp', 'asus', 'msi', 'acer', 'razer', 'corsair',
+    'logitech', 'steelseries', 'apple', 'google',
 
-      // Coding/Dev Tools
-      'python', 'idle', 'node', 'npm', 'git', 'compiler', 'debugger', 'ide',
-      'visual', 'code', 'studio', 'jetbrains', 'sublime', 'atom',
+    // Coding/Dev Tools
+    'python', 'idle', 'node', 'npm', 'git', 'compiler', 'debugger', 'ide',
+    'visual', 'code', 'studio', 'jetbrains', 'sublime', 'atom',
 
-      // Archive/Compression
-      'winrar', 'archive', '7-zip', 'zip', 'compress', 'extract', 'rar',
-      'tar', 'gzip', 'bzip2',
+    // Archive/Compression
+    'winrar', 'archive', '7-zip', 'zip', 'compress', 'extract', 'rar',
+    'tar', 'gzip', 'bzip2',
 
-      // Utilities/Tools
-      'tool', 'utility', 'helper', 'launcher', 'updater', 'optimizer',
-      'cleaner', 'uninstaller', 'manager', 'monitor', 'viewer', 'converter',
-      'recorder', 'codec', 'directx', 'vcredist', 'redist', 'runtime',
-      'bootstrap', 'bootstrapper', 'gamelaunchhelper',
+    // Utilities/Tools
+    'tool', 'utility', 'helper', 'launcher', 'updater', 'optimizer',
+    'cleaner', 'uninstaller', 'manager', 'monitor', 'viewer', 'converter',
+    'recorder', 'codec', 'directx', 'vcredist', 'redist', 'runtime',
+    'bootstrap', 'bootstrapper', 'gamelaunchhelper',
 
-      // Communication
-      'whatsapp', 'telegram', 'discord', 'slack', 'zoom', 'skype', 'teams',
+    // Communication
+    'whatsapp', 'telegram', 'discord', 'slack', 'zoom', 'skype', 'teams',
 
-      // Game Launchers & Platforms (not actual games)
-      'battle.net', 'battlenet', 'blizzard', 'steam client', 'epic games launcher',
-      'origin', 'ea desktop', 'ubisoft connect', 'gog galaxy', 'xbox app',
-      'game bar', 'game overlay', 'game launcher', 'launcher',
+    // Game Launchers & Platforms (not actual games)
+    'battle.net', 'battlenet', 'blizzard', 'steam client', 'epic games launcher',
+    'origin', 'ea desktop', 'ubisoft connect', 'gog galaxy', 'xbox app',
+    'game bar', 'game overlay', 'game launcher', 'launcher',
 
-      // Specific Problem Cases
-      'quick assist', 'snipping', 'sticky', 'hdr calibration', 'insider hub',
-      'xbox', 'console', 'terminal', 'cmd', 'powershell', 'bash', 'shell',
-      'photoshop', 'illustrator', 'premiere', 'after effects',
-    ];
-  }
+    // Specific Problem Cases
+    'quick assist', 'snipping', 'sticky', 'hdr calibration', 'insider hub',
+    'xbox', 'console', 'terminal', 'cmd', 'powershell', 'bash', 'shell',
+    'photoshop', 'illustrator', 'premiere', 'after effects',
+  ];
 
   /**
    * Executable filenames that are definitely not games
    */
-  private getNonGameExecutables(): Set<string> {
-    return new Set([
-      'setup.exe', 'uninstall.exe', 'unins000.exe',
-      'installer.exe', 'bootstrapper.exe', 'launcher.exe',
-      'updater.exe', 'config.exe',
-      'python.exe', 'pythonw.exe', 'python3.exe',
-      'node.exe', 'npm.exe', 'npm.cmd',
-      'git.exe', 'git-bash.exe',
-      'code.exe', 'codeinsiders.exe',
-      'unity.exe', 'unitycrashhandler.exe', 'unitycrashhandler64.exe',
-      'unitycrashhandler32.exe',
-      'crashreportclient.exe', 'crashpad_handler.exe',
-      'cleanup.exe', 'directxsetup.exe', 'dxsetup.exe',
-      'vc_redist.x64.exe', 'vc_redist.x86.exe',
-      'vulkan.exe', 'dxcpl.exe',
-      // Battle.net launcher executables
-      'battlenet.exe', 'battle.net.exe', 'battlenet.overlay.runtime.exe',
-      'blizzardlauncher.exe', 'blizzard.exe', 'blizzardupdate.exe',
-      'blizzardbrowser.exe', 'blizzarderror.exe', 'blizztray.exe',
-      'gamesessionmonitor.exe',
-      'quickassist.exe', 'quickassistant.exe',
-      'realtek.exe', 'snipping.exe', 'stickynotes.exe',
-      'hdr_calibration.exe', 'xbox_insider.exe',
-      'zsync.exe', 'zsyncmake.exe',
-    ]);
-  }
+  private static readonly NON_GAME_EXECUTABLES: ReadonlySet<string> = new Set([
+    'setup.exe', 'uninstall.exe', 'unins000.exe',
+    'installer.exe', 'bootstrapper.exe', 'launcher.exe',
+    'updater.exe', 'config.exe',
+    'python.exe', 'pythonw.exe', 'python3.exe',
+    'node.exe', 'npm.exe', 'npm.cmd',
+    'git.exe', 'git-bash.exe',
+    'code.exe', 'codeinsiders.exe',
+    'unity.exe', 'unitycrashhandler.exe', 'unitycrashhandler64.exe',
+    'unitycrashhandler32.exe',
+    'crashreportclient.exe', 'crashpad_handler.exe',
+    'cleanup.exe', 'directxsetup.exe', 'dxsetup.exe',
+    'vc_redist.x64.exe', 'vc_redist.x86.exe',
+    'vulkan.exe', 'dxcpl.exe',
+    // Battle.net launcher executables
+    'battlenet.exe', 'battle.net.exe', 'battlenet.overlay.runtime.exe',
+    'blizzardlauncher.exe', 'blizzard.exe', 'blizzardupdate.exe',
+    'blizzardbrowser.exe', 'blizzarderror.exe', 'blizztray.exe',
+    'gamesessionmonitor.exe',
+    'quickassist.exe', 'quickassistant.exe',
+    'realtek.exe', 'snipping.exe', 'stickynotes.exe',
+    'hdr_calibration.exe', 'xbox_insider.exe',
+    'zsync.exe', 'zsyncmake.exe',
+  ]);
+
+  /**
+   * Patterns indicating a downloading/staged game path
+   */
+  private static readonly DOWNLOAD_PATTERNS: readonly string[] = [
+    'uplay_download',
+    'steamapps\\downloading',
+    'steamapps/downloading',
+    'epicgames\\directdownload',
+    'originservice\\staged',
+    'origin games\\__origintmp',
+    'battle.net\\temp',
+    'battlenet\\temp',
+    'appdata\\local\\temp\\gog-galaxy',
+  ];
+
+  /**
+   * Regex pattern for Xbox UUIDs in paths
+   */
+  private static readonly XBOX_UUID_PATTERN = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i;
 
   /**
    * Extract publisher from folder name or app name
@@ -135,10 +148,9 @@ export class GameFilteringService {
    */
   private getPublisherFromName(name: string): string | null {
     const lowerName = name.toLowerCase();
-    const knownPublishers = this.getKnownGamePublishers();
 
     // Direct match
-    for (const pub of knownPublishers) {
+    for (const pub of GameFilteringService.KNOWN_PUBLISHERS) {
       if (lowerName.includes(pub)) {
         return pub;
       }
@@ -178,7 +190,7 @@ export class GameFilteringService {
     const exeNameL = info.exeName.toLowerCase();
 
     // STEP 1: Check exact executable name blacklist
-    if (this.getNonGameExecutables().has(exeNameL)) {
+    if (GameFilteringService.NON_GAME_EXECUTABLES.has(exeNameL)) {
       console.debug(`[GameFiltering] Excluding ${info.name}: non-game exe "${info.exeName}"`);
       return true;
     }
@@ -190,8 +202,7 @@ export class GameFilteringService {
     }
 
     // STEP 3: Check system app patterns
-    const systemPatterns = this.getSystemAppPatterns();
-    if (systemPatterns.some(pattern => nameL.includes(pattern) || exeNameL.includes(pattern))) {
+    if (GameFilteringService.SYSTEM_APP_PATTERNS.some(pattern => nameL.includes(pattern) || exeNameL.includes(pattern))) {
       console.debug(`[GameFiltering] Excluding ${info.name}: system app pattern`);
       return true;
     }
@@ -206,8 +217,7 @@ export class GameFilteringService {
     }
 
     // STEP 5: Check non-game keywords
-    const nonGameKeywords = this.getNonGameKeywords();
-    if (nonGameKeywords.some(keyword => nameL.includes(keyword) || exeNameL.includes(keyword))) {
+    if (GameFilteringService.NON_GAME_KEYWORDS.some(keyword => nameL.includes(keyword) || exeNameL.includes(keyword))) {
       console.debug(`[GameFiltering] Excluding ${info.name}: non-game keyword`);
       return true;
     }
@@ -233,27 +243,15 @@ export class GameFilteringService {
    */
   isLikelyDownloading(folderPath: string): boolean {
     const lowerPath = folderPath.toLowerCase();
-    const downloadPatterns = [
-      'uplay_download',
-      'steamapps\\downloading',
-      'steamapps/downloading',
-      'epicgames\\directdownload',
-      'originservice\\staged',
-      'origin games\\__origintmp',
-      'battle.net\\temp',
-      'battlenet\\temp',
-      'appdata\\local\\temp\\gog-galaxy',
-    ];
 
-    if (downloadPatterns.some(pattern => lowerPath.includes(pattern))) {
+    if (GameFilteringService.DOWNLOAD_PATTERNS.some(pattern => lowerPath.includes(pattern))) {
       return true;
     }
 
     // Xbox UUID pattern in path (could be download)
     // C:\XboxGames\AFA5CF80-538B-4681-A685-0C6E61521265
     // Typical Xbox UUIDs are 8-4-4-4-12 hex chars
-    const xboxUuidPattern = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i;
-    if (lowerPath.includes('xboxgames') && xboxUuidPattern.test(lowerPath)) {
+    if (lowerPath.includes('xboxgames') && GameFilteringService.XBOX_UUID_PATTERN.test(lowerPath)) {
       return true;
     }
 


### PR DESCRIPTION
💡 What: Refactored `GameFilteringService.ts` to cache constant validation sets and arrays as `private static readonly` properties rather than re-instantiating them in method calls.
🎯 Why: Methods like `getKnownGamePublishers` and `getNonGameExecutables` were called on every iteration of the directory scanning loop, causing thousands of redundant memory allocations that increase GC pressure and CPU cycles.
📊 Impact: Reduces memory allocations during game filtering to zero for the constant lookups. Expected to slightly speed up directory scanning times and reduce memory overhead during large scans.
🔬 Measurement: Run the test suite (`pnpm test`) to verify filtering logic remains unchanged. The reduction in object allocations is structurally guaranteed by the hoisting to static scope.

---
*PR created automatically by Jules for task [10196715435134221882](https://jules.google.com/task/10196715435134221882) started by @Lasikiewicz*