### PR TITLE
🎨 Palette: Add dynamic ARIA labels to Favorite toggle buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-23 - Dynamic ARIA labels for toggle states
+**Learning:** Icon-only toggle buttons (like "Favorite") must have dynamic `aria-label`s that describe the action that *will* happen (e.g., "Remove from favorites" vs "Add to favorites"), and should communicate their current state using `aria-pressed`. This provides crucial context for screen reader users that visual users get from the icon state (filled vs outlined). Furthermore, SVGs within these buttons should be explicitly hidden from screen readers using `aria-hidden="true"` and `focusable="false"` to prevent redundant or confusing announcements.
+**Action:** Always provide dynamic `aria-label` and `aria-pressed` for icon-only toggle buttons, and hide their purely decorative SVGs from screen readers.

--- a/renderer/src/components/BottomBar.tsx
+++ b/renderer/src/components/BottomBar.tsx
@@ -24,8 +24,10 @@ export const BottomBar: React.FC<BottomBarProps> = ({ game, onPlay, onFavorite, 
             className={`group p-2 rounded transition-colors ${game.favorite ? 'text-yellow-400' : 'text-gray-300 hover:bg-gray-700'
               }`}
             title="Favorite"
+            aria-label={game.favorite ? "Remove from favorites" : "Add to favorites"}
+            aria-pressed={game.favorite}
           >
-            <svg className="w-5 h-5 group- hover:animate-gentle-bounce group-hover:animate-gentle-bounce" fill={game.favorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-5 h-5 group- hover:animate-gentle-bounce group-hover:animate-gentle-bounce" fill={game.favorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
             </svg>
           </button>

--- a/renderer/src/components/GameDetailsPanel.tsx
+++ b/renderer/src/components/GameDetailsPanel.tsx
@@ -1045,9 +1045,11 @@ export const GameDetailsPanel: React.FC<GameDetailsPanelProps> = ({
                   className={`group p-2 rounded transition-colors ${game.favorite ? 'text-yellow-400' : 'text-gray-300 hover:bg-gray-700'
                     }`}
                   title="Favorite"
+                  aria-label={game.favorite ? "Remove from favorites" : "Add to favorites"}
+                  aria-pressed={game.favorite}
                   style={{ fontSize: `${rightPanelButtonSize}px` }}
                 >
-                  <svg className="w-5 h-5 group- hover:animate-gentle-bounce group-hover:animate-gentle-bounce" fill={game.favorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 group- hover:animate-gentle-bounce group-hover:animate-gentle-bounce" fill={game.favorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11.049 2.927c.3-.921 1.603-.921 1.902 0l1.519 4.674a1 1 0 00.95.69h4.915c.969 0 1.371 1.24.588 1.81l-3.976 2.888a1 1 0 00-.363 1.118l1.518 4.674c.3.922-.755 1.688-1.538 1.118l-3.976-2.888a1 1 0 00-1.176 0l-3.976 2.888c-.783.57-1.838-.197-1.538-1.118l1.518-4.674a1 1 0 00-.363-1.118l-3.976-2.888c-.784-.57-.38-1.81.588-1.81h4.914a1 1 0 00.951-.69l1.519-4.674z" />
                   </svg>
                 </button>

--- a/renderer/tests/BottomBar.a11y.test.tsx
+++ b/renderer/tests/BottomBar.a11y.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { BottomBar } from '../src/components/BottomBar';
+import type { Game } from '../src/types/game';
+
+describe('BottomBar accessibility', () => {
+    it('renders accessible label for favorite button', () => {
+        const mockGame: Game = {
+            id: 'test-1',
+            title: 'Test Game',
+            favorite: false,
+        };
+
+        render(<BottomBar game={mockGame} onFavorite={vi.fn()} />);
+
+        const favButton = screen.getByRole('button', { name: /add to favorites/i });
+        expect(favButton).toBeInTheDocument();
+        expect(favButton).toHaveAttribute('aria-pressed', 'false');
+
+        // Check SVG
+        const svg = favButton.querySelector('svg');
+        expect(svg).toHaveAttribute('aria-hidden', 'true');
+        expect(svg).toHaveAttribute('focusable', 'false');
+    });
+
+    it('renders accessible label for favorited game', () => {
+        const mockGame: Game = {
+            id: 'test-1',
+            title: 'Test Game',
+            favorite: true,
+        };
+
+        render(<BottomBar game={mockGame} onFavorite={vi.fn()} />);
+
+        const favButton = screen.getByRole('button', { name: /remove from favorites/i });
+        expect(favButton).toBeInTheDocument();
+        expect(favButton).toHaveAttribute('aria-pressed', 'true');
+    });
+});

--- a/renderer/tests/GameDetailsPanel.a11y.test.tsx
+++ b/renderer/tests/GameDetailsPanel.a11y.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { GameDetailsPanel } from '../src/components/GameDetailsPanel';
+import type { Game } from '../src/types/game';
+
+beforeAll(() => {
+    (window as any).electronAPI = {
+        getPreferences: vi.fn().mockResolvedValue({}),
+        savePreferences: vi.fn().mockResolvedValue({}),
+    };
+});
+
+describe('GameDetailsPanel accessibility', () => {
+    it('renders accessible label for favorite button', async () => {
+        const mockGame: Game = {
+            id: 'test-1',
+            title: 'Test Game',
+            favorite: false,
+        };
+
+        render(<GameDetailsPanel game={mockGame} onFavorite={vi.fn()} viewMode="grid" />);
+
+        const favButton = await screen.findByRole('button', { name: /add to favorites/i });
+        expect(favButton).toBeInTheDocument();
+        expect(favButton).toHaveAttribute('aria-pressed', 'false');
+
+        // Check SVG
+        const svg = favButton.querySelector('svg');
+        expect(svg).toHaveAttribute('aria-hidden', 'true');
+        expect(svg).toHaveAttribute('focusable', 'false');
+    });
+
+    it('renders accessible label for favorited game', async () => {
+        const mockGame: Game = {
+            id: 'test-1',
+            title: 'Test Game',
+            favorite: true,
+        };
+
+        render(<GameDetailsPanel game={mockGame} onFavorite={vi.fn()} viewMode="grid" />);
+
+        const favButton = await screen.findByRole('button', { name: /remove from favorites/i });
+        expect(favButton).toBeInTheDocument();
+        expect(favButton).toHaveAttribute('aria-pressed', 'true');
+    });
+});


### PR DESCRIPTION
💡 **What**: Added dynamic `aria-label` and `aria-pressed` states to the "Favorite" toggle button, and explicitly hid the internal SVG icon from screen readers using `aria-hidden="true"` and `focusable="false"`. Also added corresponding Vitest accessibility tests. Added `.Jules/palette.md` to track critical learnings.
🎯 **Why**: Icon-only toggle buttons rely solely on visual cues (like icon shape/color) to convey their state. By providing a dynamic `aria-label` (e.g., "Add to favorites" vs "Remove from favorites") and an `aria-pressed` state, screen reader users now get clear, actionable context.
♿ **Accessibility**: Enhanced screen reader usability for the "Favorite" action button across the application, addressing WCAG guidelines for non-text content and names/roles/values.

---
*PR created automatically by Jules for task [12143883410044393009](https://jules.google.com/task/12143883410044393009) started by @Lasikiewicz*