### PR TITLE
⚡ Bolt: Add CSS content-visibility to LibraryListView

### DIFF
--- a/renderer/src/components/LibraryListView.tsx
+++ b/renderer/src/components/LibraryListView.tsx
@@ -189,6 +189,12 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                 className={`p-3 bg-gray-800/40 backdrop-blur-md border border-white/5 rounded-xl transition-all duration-300 hover:bg-gray-700/60 hover:border-cyan-400/30 cursor-pointer group outline-none ${index === focusedIndex ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''
                   } ${displayMode === 'logo-only' || displayMode === 'title-only' ? 'flex flex-col items-center' : 'flex items-center gap-4'
                   }`}
+                // Native virtualization for list items:
+                // Skips rendering off-screen elements, improving scroll performance for large libraries
+                style={{
+                  contentVisibility: 'auto',
+                  containIntrinsicSize: 'auto 150px'
+                }}
               >
                 {displayMode === 'title-only' ? (
                   <>


### PR DESCRIPTION
💡 **What**: Added `contentVisibility: 'auto'` and `containIntrinsicSize: 'auto 150px'` to the item wrappers in `LibraryListView.tsx`.

🎯 **Why**: Long lists of games can cause performance issues because the browser tries to render all DOM elements at once, even those not currently visible on the screen.

📊 **Impact**: Reduces rendering workload by skipping off-screen list items natively, lowering memory usage and improving scroll performance for large libraries without the overhead of JS-based virtualization.

🔬 **Measurement**: Verify by inspecting the DOM in the developer tools. Off-screen elements will have `content-visibility: auto`, meaning their contents are not painted or laid out until they enter the viewport.

Verified frontend via Playwright script capturing the `library_list_view` layout locally. Tests pass and pre-commit checks are satisfied.

---
*PR created automatically by Jules for task [5128506786681204550](https://jules.google.com/task/5128506786681204550) started by @Lasikiewicz*