### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to modal close buttons

### DIFF
--- a/renderer/src/components/AddGameModal.tsx
+++ b/renderer/src/components/AddGameModal.tsx
@@ -86,6 +86,7 @@ export const AddGameModal: React.FC<AddGameModalProps> = ({ isOpen, onClose, onA
               onClick={handleClose}
               disabled={isSubmitting}
               className="text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+              aria-label="Close"
             >
               <svg className="w-6 h-6 group- hover:animate-wobble group-hover:animate-wobble"
                 fill="none"

--- a/renderer/src/components/ModalsA11y.test.tsx
+++ b/renderer/src/components/ModalsA11y.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { AddGameModal } from './AddGameModal';
+import { RemoveDeletedGamesDialog } from './RemoveDeletedGamesDialog';
+
+describe('Modal close buttons accessibility', () => {
+  it('AddGameModal has aria-label on close button', () => {
+    // Mock the electronAPI for AddGameModal
+    (window as any).electronAPI = {
+      showOpenDialog: vi.fn(),
+      addCustomGame: vi.fn(),
+    };
+
+    render(<AddGameModal isOpen={true} onClose={() => {}} onAdd={async () => {}} />);
+
+    // Attempt to find the close button using aria-label
+    const closeButton = screen.getByLabelText('Close');
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton.tagName).toBe('BUTTON');
+  });
+
+  it('RemoveDeletedGamesDialog has aria-label on close button', () => {
+    render(
+      <RemoveDeletedGamesDialog
+        isOpen={true}
+        missingGames={[]}
+        isScanning={false}
+        onRemove={async () => {}}
+        onCancel={() => {}}
+      />
+    );
+
+    // Attempt to find the close button using aria-label
+    const closeButton = screen.getByLabelText('Close');
+    expect(closeButton).toBeInTheDocument();
+    expect(closeButton.tagName).toBe('BUTTON');
+  });
+});

--- a/renderer/src/components/RemoveDeletedGamesDialog.tsx
+++ b/renderer/src/components/RemoveDeletedGamesDialog.tsx
@@ -75,6 +75,7 @@ export const RemoveDeletedGamesDialog: React.FC<RemoveDeletedGamesDialogProps> =
                     <button
                         onClick={onCancel}
                         className="group p-2 hover:bg-white/5 rounded-xl transition-all"
+                        aria-label="Close"
                     >
                         <svg className="w-6 h-6 text-slate-500 group-hover:text-white transition-colors group-hover:animate-wobble" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
💡 What: Added `aria-label="Close"` to the icon-only "X" close buttons in `AddGameModal.tsx` and `RemoveDeletedGamesDialog.tsx`. Also added a targeted unit test (`ModalsA11y.test.tsx`) to assert this accessibility fix.
🎯 Why: Screen reader users wouldn't know what these icon-only buttons do without an accessible name. This small <50 line UX fix ensures compliance and a better experience for assistive technology.
♿ Accessibility: Improved keyboard/screen reader accessibility by providing an explicit accessible name for previously unlabeled SVG buttons.

---
*PR created automatically by Jules for task [11444337279479371374](https://jules.google.com/task/11444337279479371374) started by @Lasikiewicz*