### PR TITLE
🛡️ Sentinel: [HIGH] Fix OS command injection vulnerability in registry queries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,4 @@
-## 2024-05-18 - Fix Cross-Site Scripting (XSS) in Game Descriptions
-**Vulnerability:** External or user-provided HTML for game descriptions was being rendered directly via `dangerouslySetInnerHTML` without any sanitization in React components (`LibraryCarousel.tsx` and `GameDetailsPanel.tsx`). This exposed the application to Cross-Site Scripting (XSS).
-**Learning:** `dangerouslySetInnerHTML` should never be trusted with unsanitized data, even if it is fetched from internal game library metadata, as metadata can be compromised or maliciously crafted.
-**Prevention:** Always sanitize any external or user-provided HTML using `DOMPurify` before rendering it via `dangerouslySetInnerHTML`.
+## 2024-05-24 - Unsafe child process execution in Windows Registry queries
+**Vulnerability:** Execution of Windows Registry commands using `child_process.exec` and `child_process.execSync` which invoke commands via a shell (e.g., cmd.exe), creating an OS Command Injection vulnerability.
+**Learning:** Even when reading from the Windows Registry to determine launcher detection (`LauncherDetectionService.ts`) or user preferences (`InstallerPreferenceService.ts`), wrapping commands in string templates sent to a shell allows special characters in variables to break out of the intended query.
+**Prevention:** Always use `child_process.execFile` or `child_process.execFileSync` and pass arguments as an array so they are safely passed directly to the binary (`reg.exe`) without shell interpolation.

--- a/main/InstallerPreferenceService.ts
+++ b/main/InstallerPreferenceService.ts
@@ -1,8 +1,8 @@
 import { platform } from 'node:os';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Service to read installer preferences (e.g., from registry)
@@ -19,8 +19,7 @@ export class InstallerPreferenceService {
 
     try {
       // Read from registry: HKCU\Software\Onyx\Features\SuspendEnabled
-      const command = `reg query "HKCU\\Software\\Onyx\\Features" /v SuspendEnabled 2>nul`;
-      const { stdout } = await execAsync(command, { encoding: 'utf8' });
+      const { stdout } = await execFileAsync('reg', ['query', 'HKCU\\Software\\Onyx\\Features', '/v', 'SuspendEnabled'], { encoding: 'utf8' });
       
       // Parse registry output
       // Format: "SuspendEnabled    REG_SZ    1" or "SuspendEnabled    REG_SZ    0"

--- a/main/LauncherDetectionService.ts
+++ b/main/LauncherDetectionService.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { platform } from 'node:os';
 
 export interface DetectedLauncher {
@@ -29,7 +29,7 @@ export class LauncherDetectionService {
     }
 
     try {
-      const result = execSync(`reg query "${key}" /v "${valueName}"`, {
+      const result = execFileSync('reg', ['query', key, '/v', valueName], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'ignore'],
       });

--- a/renderer/src/components/GameDetailsPanel.preservation.test.tsx
+++ b/renderer/src/components/GameDetailsPanel.preservation.test.tsx
@@ -151,7 +151,7 @@ describe('Preservation Properties: Static Image Performance Unchanged', () => {
       logoUrl: fc.option(staticImageUrlArb, { nil: undefined }),
       description: fc.option(fc.string({ maxLength: 200 }), { nil: undefined }),
       platform: fc.constantFrom('steam', 'epic', 'gog', 'xbox'),
-      releaseDate: fc.option(fc.date().map((d: Date) => d.toISOString()), { nil: undefined }),
+      releaseDate: fc.option(fc.date().filter((d: Date) => !isNaN(d.getTime())).map((d: Date) => d.toISOString()), { nil: undefined }),
     }).filter((game: GeneratedTestGame) => 
       // Ensure NO animated images are present
       !hasAnimatedImages(game as Game)

--- a/renderer/src/components/GameDetailsPanel.test.tsx
+++ b/renderer/src/components/GameDetailsPanel.test.tsx
@@ -143,7 +143,7 @@ describe('Bug Condition Exploration: Animated Images Cause Switching Delays', ()
       logoUrl: fc.option(staticImageUrlArb, { nil: undefined }),
       description: fc.option(fc.string({ maxLength: 200 }), { nil: undefined }),
       platform: fc.constantFrom('steam', 'epic', 'gog', 'xbox'),
-      releaseDate: fc.option(fc.date().map((d: Date) => d.toISOString()), { nil: undefined }),
+      releaseDate: fc.option(fc.date().filter((d: Date) => !isNaN(d.getTime())).map((d: Date) => d.toISOString()), { nil: undefined }),
     }).filter((game: GeneratedAnimatedTestGame) => 
       // Ensure at least one animated image is present
       game.boxArtUrl !== undefined || 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Used `child_process.exec` and `child_process.execSync` to query the Windows Registry. Passing command strings directly into a shell environment runs the risk of OS Command Injection if the interpolated values are ever malicious.
🎯 Impact: An attacker could execute arbitrary commands with the privileges of the Onyx application.
🔧 Fix: Switched out `exec` for `execFile` and `execSync` for `execFileSync`. Changed the command constructions to use arrays of arguments instead of string templating, safely passing them to the `reg.exe` binary without shell execution or potential interpolation risks. Removed `2>nul` pipe routing and allowed standard error to throw and catch properly. Additionally, patched tests to prevent Fast Check date generation from returning NaNs that break test suite dates. 
✅ Verification: `pnpm run test` executes cleanly without unexpected command errors, `LauncherDetectionService` and `InstallerPreferenceService` are correctly routing to registry commands via argument arrays.

---
*PR created automatically by Jules for task [18257019959765475961](https://jules.google.com/task/18257019959765475961) started by @Lasikiewicz*