### PR TITLE
⚡ Bolt: Add native lazy loading to LibraryListView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-03-12 - Native Lazy Loading over Custom Intersection Observer
+**Learning:** Found an opportunity to improve image rendering performance by utilizing the native `loading="lazy"` attribute on `<img>` tags instead of building complex custom lazy loading hooks or relying purely on `content-visibility: auto` for list items. Native lazy loading defers off-screen images optimally, drastically reducing initial bandwidth and CPU parsing overhead when rendering large lists like `LibraryListView`.
+**Action:** When working with image-heavy lists or grid components, always verify if `loading="lazy"` is applied to `<img>` tags. Combine it with container-level `contentVisibility: 'auto'` where appropriate for maximal performance.

--- a/renderer/src/components/LibraryListView.tsx
+++ b/renderer/src/components/LibraryListView.tsx
@@ -285,6 +285,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                              loading="lazy"
                             className="max-w-full max-h-full object-contain transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -384,6 +385,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.iconUrl}
                             alt={game.title}
+                              loading="lazy"
                             className="max-w-full max-h-full object-contain"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -498,6 +500,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.boxArtUrl}
                             alt={game.title}
+                              loading="lazy"
                             className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -523,6 +526,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                              loading="lazy"
                             className="w-full h-full object-contain p-2 transition-transform duration-300 group-hover:scale-110"
                             style={{ width: `${logoSizeForList}px`, height: `${Math.round(logoSizeForList * (4 / 3))}px` }}
                             onError={(e) => {


### PR DESCRIPTION
💡 What: Added `loading="lazy"` attribute to all `<img>` tags within `LibraryListView.tsx` to utilize native browser lazy loading.
🎯 Why: When scrolling through large lists in the Library view, many images were being loaded synchronously which could cause unnecessary bandwidth consumption and delay the rendering of the initial visible assets. 
📊 Impact: Considerably reduces initial network requests and CPU parsing when opening a large game library list view by deferring off-screen image loading.
🔬 Measurement: Verify by opening network devtools while rendering a large library view and scrolling through. You should only see image requests as they come closer to the viewport rather than all at once.

---
*PR created automatically by Jules for task [14247572455984799885](https://jules.google.com/task/14247572455984799885) started by @Lasikiewicz*