### PR TITLE
🎨 Palette: [UX improvement] Add aria-labels to icon-only buttons

### DIFF
--- a/renderer/src/components/GameLinks.tsx
+++ b/renderer/src/components/GameLinks.tsx
@@ -610,6 +610,7 @@ export const GameLinks: React.FC<GameLinksProps> = ({
                                                 disabled={link.originalIndex === 0}
                                                 className="p-1 text-gray-500 hover:text-white hover:bg-white/10 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                                                 title="Move Priority Up"
+                                                aria-label="Move Priority Up"
                                             >
                                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 15l7-7 7 7" />
@@ -622,6 +623,7 @@ export const GameLinks: React.FC<GameLinksProps> = ({
                                                 disabled={link.originalIndex === links.length - 1}
                                                 className="p-1 text-gray-500 hover:text-white hover:bg-white/10 rounded transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
                                                 title="Move Priority Down"
+                                                aria-label="Move Priority Down"
                                             >
                                                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M19 9l-7 7-7-7" />
@@ -635,6 +637,7 @@ export const GameLinks: React.FC<GameLinksProps> = ({
                                                 onClick={() => toggleHideLink(link.originalIndex)}
                                                 className="p-1 text-gray-500 hover:text-white hover:bg-white/10 rounded transition-colors"
                                                 title={link.hidden ? "Show Link" : "Hide Link"}
+                                                aria-label={link.hidden ? "Show Link" : "Hide Link"}
                                             >
                                                 {link.hidden ? (
                                                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/renderer/src/components/ImageSearchModal.tsx
+++ b/renderer/src/components/ImageSearchModal.tsx
@@ -144,6 +144,7 @@ export const ImageSearchModal: React.FC<ImageSearchModalProps> = ({
             <button
               onClick={onClose}
               className="text-gray-400 hover:text-white transition-colors"
+              aria-label="Close image search"
             >
               <svg className="w-6 h-6 group- hover:animate-wobble group-hover:animate-wobble" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/renderer/src/components/importer/ImageSearchModal.tsx
+++ b/renderer/src/components/importer/ImageSearchModal.tsx
@@ -92,7 +92,7 @@ export const ImageSearchModal: React.FC<ImageSearchModalProps> = ({
                             {isSearching ? 'Searching...' : 'Search'}
                         </button>
                     </div>
-                    <button onClick={onClose} className="p-2 hover:bg-gray-800 rounded-lg text-gray-400 hover:text-white text-2xl">×</button>
+                    <button onClick={onClose} aria-label="Close image search" className="p-2 hover:bg-gray-800 rounded-lg text-gray-400 hover:text-white text-2xl">×</button>
                 </div>
 
                 {/* Content */}


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons (like the close buttons in modals and link management buttons).
🎯 Why: To improve screen reader usability for visually impaired users. Buttons that rely solely on SVG icons are read as "button" or not at all by screen readers without a proper accessible label.
♿ Accessibility: Ensures that screen readers can convey the correct intent of interactive elements.

---
*PR created automatically by Jules for task [8889368583534094190](https://jules.google.com/task/8889368583534094190) started by @Lasikiewicz*