### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection vulnerability

### DIFF
--- a/main/InstallerPreferenceService.ts
+++ b/main/InstallerPreferenceService.ts
@@ -1,8 +1,8 @@
 import { platform } from 'node:os';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /**
  * Service to read installer preferences (e.g., from registry)
@@ -19,8 +19,7 @@ export class InstallerPreferenceService {
 
     try {
       // Read from registry: HKCU\Software\Onyx\Features\SuspendEnabled
-      const command = `reg query "HKCU\\Software\\Onyx\\Features" /v SuspendEnabled 2>nul`;
-      const { stdout } = await execAsync(command, { encoding: 'utf8' });
+      const { stdout } = await execFileAsync('reg', ['query', 'HKCU\\Software\\Onyx\\Features', '/v', 'SuspendEnabled'], { encoding: 'utf8' });
       
       // Parse registry output
       // Format: "SuspendEnabled    REG_SZ    1" or "SuspendEnabled    REG_SZ    0"

--- a/main/ProcessSuspendService.ts
+++ b/main/ProcessSuspendService.ts
@@ -1,8 +1,8 @@
-import { spawn, exec } from 'child_process';
+import { spawn, execFile } from 'child_process';
 import path from 'node:path';
 import { platform } from 'node:os';
 import { promisify } from 'util';
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 type ExecRunner = (command: string, args: string[], opts?: any) => Promise<{ stdout: string; stderr: string; code: number }>;
 
@@ -410,8 +410,7 @@ ${shouldForeground ? '[OnyxUser32]::SetForegroundWindow($hWnd) | Out-Null' : ''}
     }
 
     try {
-      const command = `powershell -Command "Get-Process -Id ${pid} -ErrorAction SilentlyContinue"`;
-      const { stdout } = await execAsync(command);
+      const { stdout } = await execFileAsync('powershell', ['-NoProfile', '-Command', `Get-Process -Id ${pid} -ErrorAction SilentlyContinue`]);
       return stdout.trim().length > 0;
     } catch {
       return false;
@@ -427,8 +426,7 @@ ${shouldForeground ? '[OnyxUser32]::SetForegroundWindow($hWnd) | Out-Null' : ''}
     }
 
     try {
-      const command = `powershell -Command "Get-Process | Select-Object Id, ProcessName, Path | ConvertTo-Json"`;
-      const { stdout } = await execAsync(command);
+      const { stdout } = await execFileAsync('powershell', ['-NoProfile', '-Command', 'Get-Process | Select-Object Id, ProcessName, Path | ConvertTo-Json']);
       const processes = JSON.parse(stdout);
 
       // Handle both single object and array


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection vulnerability due to the use of `exec` to execute shell commands with unsanitized arguments.
🎯 Impact: An attacker could potentially execute arbitrary commands on the user's system by crafting malicious input that gets passed to `exec`.
🔧 Fix: Replaced `exec` with `execFile` which does not spawn a shell by default, preventing command injection.
✅ Verification: I have reviewed the code to ensure that `execFile` is used instead of `exec` and that the arguments are passed as an array.

---
*PR created automatically by Jules for task [5658845962576280934](https://jules.google.com/task/5658845962576280934) started by @Lasikiewicz*