### PR TITLE
🎨 Palette: [UX improvement] Add disabled cursor to AddGameModal inputs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,10 @@ importers:
       sharp:
         specifier: ^0.34.5
         version: 0.34.5
+    optionalDependencies:
+      keytar:
+        specifier: ^7.7.0
+        version: 7.9.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
@@ -108,10 +112,6 @@ importers:
       wait-on:
         specifier: ^7.2.0
         version: 7.2.0
-    optionalDependencies:
-      keytar:
-        specifier: ^7.7.0
-        version: 7.9.0
 
 packages:
 

--- a/renderer/src/components/AddGameModal.tsx
+++ b/renderer/src/components/AddGameModal.tsx
@@ -113,7 +113,7 @@ export const AddGameModal: React.FC<AddGameModalProps> = ({ isOpen, onClose, onA
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
                 disabled={isSubmitting}
-                className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                className="w-full px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 placeholder="Enter game title"
                 autoFocus
               />
@@ -130,7 +130,7 @@ export const AddGameModal: React.FC<AddGameModalProps> = ({ isOpen, onClose, onA
                   value={exePath}
                   readOnly
                   disabled={isSubmitting}
-                  className="flex-1 px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                  className="flex-1 px-4 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                   placeholder="No file selected"
                 />
                 <button


### PR DESCRIPTION
💡 What: Added the `disabled:cursor-not-allowed` Tailwind class to the input fields in `AddGameModal.tsx`.
🎯 Why: To improve visual feedback by clearly indicating to the user that these fields cannot be interacted with while the form is submitting.
📸 Before/After: Before, hovering over disabled inputs during submission showed a regular cursor. After, it shows the "not-allowed" cursor.
♿ Accessibility: Improved interaction clarity for disabled states.

---
*PR created automatically by Jules for task [10973016119710062397](https://jules.google.com/task/10973016119710062397) started by @Lasikiewicz*