### PR TITLE
⚡ Bolt: [performance improvement] Optimize LibraryListView Rendering

### DIFF
--- a/renderer/src/components/LibraryListView.tsx
+++ b/renderer/src/components/LibraryListView.tsx
@@ -41,7 +41,7 @@ interface LibraryListViewProps {
   onEmptySpaceClick?: (x: number, y: number) => void;
 }
 
-export const LibraryListView: React.FC<LibraryListViewProps> = ({
+export const LibraryListView = React.memo(({
   games,
   onPlay,
   onGameClick,
@@ -68,7 +68,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
   },
   listViewSize = 128,
   onEmptySpaceClick,
-}) => {
+}: LibraryListViewProps) => {
   const formatPlaytime = (minutes?: number) => {
     if (!minutes) return 'Not Played';
     if (minutes < 60) return `${minutes} minutes`;
@@ -189,6 +189,10 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                 className={`p-3 bg-gray-800/40 backdrop-blur-md border border-white/5 rounded-xl transition-all duration-300 hover:bg-gray-700/60 hover:border-cyan-400/30 cursor-pointer group outline-none ${index === focusedIndex ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''
                   } ${displayMode === 'logo-only' || displayMode === 'title-only' ? 'flex flex-col items-center' : 'flex items-center gap-4'
                   }`}
+                style={{
+                  contentVisibility: 'auto',
+                  containIntrinsicSize: `auto ${tileHeight > 0 ? tileHeight : 128}px`
+                }}
               >
                 {displayMode === 'title-only' ? (
                   <>
@@ -285,6 +289,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="max-w-full max-h-full object-contain transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -384,6 +389,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.iconUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="max-w-full max-h-full object-contain"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -498,6 +504,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.boxArtUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -523,6 +530,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="w-full h-full object-contain p-2 transition-transform duration-300 group-hover:scale-110"
                             style={{ width: `${logoSizeForList}px`, height: `${Math.round(logoSizeForList * (4 / 3))}px` }}
                             onError={(e) => {
@@ -635,4 +643,4 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
       )}
     </div>
   );
-};
+});


### PR DESCRIPTION
💡 What
- Applied `React.memo` to `LibraryListView` to prevent unnecessary re-renders.
- Added `loading="lazy"` to all `<img>` tags for artwork (logos, icons, boxart).
- Added `contentVisibility: 'auto'` and `containIntrinsicSize` to list items.

🎯 Why
- The game library can contain hundreds of items. Rendering all DOM nodes and downloading all images simultaneously caused significant main thread blocking and memory spikes during initial load.
- Re-renders of the parent component caused the entire library list to unnecessarily re-evaluate.

📊 Impact
- Reduces memory footprint and initial network request surge by deferring off-screen image loads.
- Substantially improves scroll performance and initial render time for large lists via native CSS virtualization.
- Eliminates unnecessary React tree reconciliations when unrelated context/state updates occur above the library view.

🔬 Measurement
- Scroll through a large game library and observe the Network tab: image requests should trigger only as items approach the viewport.
- Profile a React state change in the parent container: `LibraryListView` should skip rendering unless its props have changed.

---
*PR created automatically by Jules for task [6231576610775307822](https://jules.google.com/task/6231576610775307822) started by @Lasikiewicz*