### PR TITLE
⚡ Bolt: [performance improvement] Implement native virtualization via content-visibility in LibraryListView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Content Visibility as Native Virtualization
+**Learning:** For lists in React where traditional virtualization libraries introduce too much complexity or DOM-thrashing overhead, CSS properties `contentVisibility: 'auto'` paired with `containIntrinsicSize` act as a lightweight, native browser alternative to virtualization. This instructs the browser to skip layout and painting for off-screen items.
+**Action:** When optimizing long lists, use `contentVisibility: 'auto'` on list item containers and provide a `containIntrinsicSize` placeholder size to prevent scrollbar jumping. Always combine this with `loading="lazy"` on nested media.

--- a/renderer/src/components/LibraryListView.tsx
+++ b/renderer/src/components/LibraryListView.tsx
@@ -189,6 +189,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                 className={`p-3 bg-gray-800/40 backdrop-blur-md border border-white/5 rounded-xl transition-all duration-300 hover:bg-gray-700/60 hover:border-cyan-400/30 cursor-pointer group outline-none ${index === focusedIndex ? 'ring-2 ring-blue-500 ring-offset-2 ring-offset-slate-900' : ''
                   } ${displayMode === 'logo-only' || displayMode === 'title-only' ? 'flex flex-col items-center' : 'flex items-center gap-4'
                   }`}
+                style={{ contentVisibility: 'auto', containIntrinsicSize: `auto ${tileHeight || 128}px` }}
               >
                 {displayMode === 'title-only' ? (
                   <>
@@ -285,6 +286,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="max-w-full max-h-full object-contain transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -384,6 +386,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.iconUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="max-w-full max-h-full object-contain"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -498,6 +501,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.boxArtUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-110"
                             onError={(e) => {
                               const target = e.target as HTMLImageElement;
@@ -523,6 +527,7 @@ export const LibraryListView: React.FC<LibraryListViewProps> = ({
                           <img
                             src={game.logoUrl}
                             alt={game.title}
+                            loading="lazy"
                             className="w-full h-full object-contain p-2 transition-transform duration-300 group-hover:scale-110"
                             style={{ width: `${logoSizeForList}px`, height: `${Math.round(logoSizeForList * (4 / 3))}px` }}
                             onError={(e) => {


### PR DESCRIPTION
## 💡 What
Added `contentVisibility: 'auto'` and `containIntrinsicSize` to list item containers within `LibraryListView`, acting as a lightweight native virtualization alternative. Additionally, added `loading="lazy"` to all `<img>` tags within the component to defer off-screen media loading.

## 🎯 Why
Rendering large lists of games with full DOM layouts and eager image loading can cause significant main-thread blocking, high memory consumption, and scroll jank. Implementing a heavy virtualization library would introduce unnecessary architectural complexity. These native browser features resolve the performance bottleneck gracefully.

## 📊 Impact
- Substantial reduction in initial layout and paint times for the list view.
- Lower overall memory footprint since off-screen items defer their rendering work and image fetching.
- Smoother scrolling performance for large game libraries.

## 🔬 Measurement
1. Open the application with a large library.
2. Switch to the List View.
3. Observe memory usage and scroll performance via browser dev tools. Images will only load as they approach the viewport, and the browser will skip rendering the internal contents of off-screen list items.

*Note: Documented findings in `.jules/bolt.md`.*

---
*PR created automatically by Jules for task [14955883172205009540](https://jules.google.com/task/14955883172205009540) started by @Lasikiewicz*